### PR TITLE
feat: Support environment variable authentication with persistent credentials (#17)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .json
 
 # Local files
+.cursor/
 volumes/
 env/
 log/

--- a/src/ssky/login.py
+++ b/src/ssky/login.py
@@ -3,7 +3,14 @@ import atproto_client
 from ssky.profile_list import ProfileList
 from ssky.ssky_session import SskySession
 
-def login(handle=None, password=None, **kwargs) -> list:
+def login(credentials=None, **kwargs) -> list:
+    handle = None
+    password = None
+    
+    # Parse credentials if provided
+    if credentials is not None and ':' in credentials:
+        handle, password = credentials.split(':', 1)
+    
     try:
         session = SskySession(handle=handle, password=password)
         session.persist()

--- a/src/ssky/login.py
+++ b/src/ssky/login.py
@@ -3,7 +3,7 @@ import atproto_client
 from ssky.profile_list import ProfileList
 from ssky.ssky_session import SskySession
 
-def login(credentials=None, **kwargs) -> list:
+def login(credentials=None, **kwargs) -> ProfileList:
     handle = None
     password = None
     

--- a/src/ssky/main.py
+++ b/src/ssky/main.py
@@ -40,8 +40,7 @@ def parse():
     get_parser.add_argument('target', nargs='?', type=str, default=None, metavar='PARAM', help='URI(at://...), DID(did:...), handle, or none as timeline')
 
     login_parser = sp.add_parser('login', formatter_class=SortingHelpFormatter, parents=[delimiter_options, format_options], help='Login')
-    login_parser.add_argument('handle', nargs='?', type=str, default=None, help='User handle')
-    login_parser.add_argument('password', nargs='?', type=str, default=None, help='User password')
+    login_parser.add_argument('credentials', nargs='?', type=str, default=None, help='User credentials (handle:password)')
 
     post_parser = sp.add_parser('post', formatter_class=SortingHelpFormatter, parents=[delimiter_options, format_options], help='Post a message to the timeline')
     post_parser.add_argument('message', nargs='?', type=str, help='The message to post')

--- a/src/ssky/ssky_session.py
+++ b/src/ssky/ssky_session.py
@@ -32,31 +32,30 @@ class SskySession:
         if SskySession.session is None:
             var_user = os.environ.get('SSKY_USER')
             
-            # Try environment variable first
-            if var_user is not None:
-                handle, password = var_user.split(':', 1)
-                cls.session = cls.at_login_internal(handle=handle, password=password)
-            # Try provided arguments
-            elif handle is not None and password is not None:
-                cls.session = cls.at_login_internal(handle=handle, password=password)
-            # Try session file with fallback to environment variable
-            elif os.path.exists(cls.config_path) and os.path.isfile(cls.config_path):
+            # Try session file first (most efficient)
+            session_login_succeeded = False
+            if os.path.exists(cls.config_path) and os.path.isfile(cls.config_path):
                 with open(cls.config_path, 'r') as f:
                     persistent_config = json.load(f)
                     session_string = persistent_config.get('session_string')
                 try:
                     cls.session = cls.at_login_internal(session_string=session_string)
+                    session_login_succeeded = True
                 except atproto_client.exceptions.AtProtocolError:
-                    # If session_string login fails, try SSKY_USER as fallback
-                    if var_user is not None:
-                        handle, password = var_user.split(':', 1)
-                        cls.session = cls.at_login_internal(handle=handle, password=password)
-                    else:
-                        cls.session = cls.login_failed
-                        raise atproto_client.exceptions.LoginRequiredError('Session expired and no SSKY_USER found. Please set SSKY_USER or run ssky login handle:password')
-            else:
-                cls.session = cls.login_failed
-                raise atproto_client.exceptions.LoginRequiredError('No credentials found. Please set SSKY_USER or run ssky login handle:password')
+                    pass  # Will try fallback credentials
+            
+            # If session login failed or no session file exists, try other credentials
+            if not session_login_succeeded:
+                # Try command line arguments (explicit specification)
+                if handle is not None and password is not None:
+                    cls.session = cls.at_login_internal(handle=handle, password=password)
+                # Try environment variable (fallback)
+                elif var_user is not None:
+                    handle, password = var_user.split(':', 1)
+                    cls.session = cls.at_login_internal(handle=handle, password=password)
+                else:
+                    cls.session = cls.login_failed
+                    raise atproto_client.exceptions.LoginRequiredError('No credentials found. Please set SSKY_USER or run ssky login handle:password')
 
     @classmethod
     def persist_internal(cls) -> None:

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,61 +1,52 @@
 import os
 
 from ssky.login import login
+from ssky.profile_list import ProfileList
 from ssky.ssky_session import SskySession
 from tests.common import setup, teardown
 
-def test_login_with_handle_and_password():
+def test_login_using_credentials():
+    """Test login with handle:password credentials format"""
     SskySession.clear()
     setup(no_session_file=True)
-    handle, password = os.environ.get('SSKY_USER').split(':')
-    result = login(handle=handle, password=password)
+    credentials = os.environ.get('SSKY_USER')
+    result = login(credentials=credentials)
     with open(os.path.expanduser('~/.ssky'), 'r') as f:
         session_string = f.read()
-    status = len(result) == 2 and type(result[0]) is str and type(result[1]) is str and session_string is not None
+    status = type(result) is ProfileList and session_string is not None
+    teardown() 
+    SskySession.clear()
+    assert status
+
+def test_login_using_environment_variable():
+    """Test login using SSKY_USER environment variable"""
+    SskySession.clear()
+    setup(no_session_file=True)
+    result = login()
+    with open(os.path.expanduser('~/.ssky'), 'r') as f:
+        session_string = f.read()
+    status = type(result) is ProfileList and session_string is not None
     teardown()
     SskySession.clear()
     assert status
 
-def test_login_with_no_args_and_from_session_file():
+def test_login_using_session_file():
+    """Test login using existing session file"""
     SskySession.clear()
     setup(envs_to_delete=['SSKY_USER'])
     result = login()
-    status = result is not None and len(result) == 2 and type(result[0]) is str and type(result[1]) is str
+    with open(os.path.expanduser('~/.ssky'), 'r') as f:
+        session_string = f.read()
+    status = type(result) is ProfileList and session_string is not None
     teardown()
     SskySession.clear()
     assert status
 
-def test_login_with_no_args_and_from_env():
-    SskySession.clear()
-    setup(no_session_file=True)
-    result = login()
-    status = result is not None and len(result) == 2 and type(result[0]) is str and type(result[1]) is str
-    teardown()
-    SskySession.clear()
-    assert status
-
-def test_login_with_no_args_and_no_env():
+def test_login_using_no_credentials():
+    """Test login failure when no credentials available"""
     SskySession.clear()
     setup(envs_to_delete=['SSKY_USER'], no_session_file=True)
     result = login()
-    status = result is None
-    teardown()
-    SskySession.clear()
-    assert status
-
-def test_login_with_handle_and_no_password():
-    SskySession.clear()
-    setup(envs_to_delete=['SSKY_USER'], no_session_file=True)
-    result = login(handle=os.environ.get('SSKY_HANDLE'), password=None)
-    status = result is None
-    teardown()
-    SskySession.clear()
-    assert status
-
-def test_login_with_no_handle_and_password():
-    SskySession.clear()
-    setup(envs_to_delete=['SSKY_USER'], no_session_file=True)
-    result = login(handle=None, password=os.environ.get('SSKY_PASSWORD'))
     status = result is None
     teardown()
     SskySession.clear()


### PR DESCRIPTION
Closes #17

## Summary

This PR implements unified authentication format and improved session recovery as specified in issue #17.

## Changes

### 🔧 **Main Implementation**
- **Unified credential format**: `ssky login handle:password` 
- **Enhanced authentication priority**: Session file → Command line → Environment variable
- **Automatic session recovery**: Fallback to `SSKY_USER` when session expires
- **Improved error messages**: Clear guidance for users

### 📝 **Code Changes**
- **main.py**: Updated login parser to use single `credentials` argument
- **login.py**: Added `handle:password` format parsing with `split(':', 1)`
- **ssky_session.py**: Reordered authentication priority and added session recovery
- **tests**: Updated all test cases to work with new credential format

### 🎯 **New Usage Patterns**
```bash
# Environment variable (recommended)
export SSKY_USER=handle:password
ssky login

# Direct credentials
ssky login handle:password

# Automatic session usage
ssky get  # Uses existing session, falls back to SSKY_USER if expired
```

## Testing

All login tests pass:
- ✅ Login with credentials parameter
- ✅ Login using environment variable
- ✅ Login using session file
- ✅ Proper failure handling

## Backward Compatibility

- ✅ Existing session files continue to work
- ✅ `SSKY_USER` environment variable works as before
- ⚠️ **Breaking change**: Command line arguments changed from `handle password` to `handle:password`