### PR TITLE
Fix Pydantic validation error in `ssky profile myself` command

### DIFF
--- a/src/ssky/profile.py
+++ b/src/ssky/profile.py
@@ -9,7 +9,7 @@ def profile(name, **kwargs) -> ProfileList:
         if profile is None:
             print(f'Profile not found', file=sys.stderr)
             return None
-        return ProfileList().append(profile)
+        return ProfileList().append(profile.did)
     except atproto_client.exceptions.AtProtocolError as e:
         if 'response' in dir(e) and e.response is not None:
             print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)


### PR DESCRIPTION
## Problem

The `ssky profile myself` command throws the following Pydantic validation error:

```
2 validation errors for Params
actors.0.`function-before[<atproto_client.models.string_formats._NamedValidator object at 0x7f7ac7b38ad0>(), str]`
  Input should be a valid string [type=string_type, input_value=ProfileViewDetailed(did='...fs#profileViewDetailed'), input_type=ProfileViewDetailed]
```

## Root Cause

In `src/ssky/profile.py` line 11, the entire `ProfileViewDetailed` object was being passed to the `ProfileList.append()` method, but this method expects a string (DID).

```python
# Problematic code
return ProfileList().append(profile)
```

## Solution

Fixed by passing `profile.did` instead:

```python
# Fixed code  
return ProfileList().append(profile.did)
```

This approach is consistent with other similar functions (`follow.py`, `login.py`, etc.).

## Impact

- The `ssky profile` command now works correctly
- Pydantic validation errors are resolved
- No impact on existing functionality

## Testing

After the fix, the `ssky profile myself` command executes without errors.

## Changes

- Modified `src/ssky/profile.py` line 11 to pass `profile.did` instead of the entire `profile` object