### PR TITLE
feat: use dynamic version from package metadata in MCP server

### DIFF
--- a/mcp/ssky_server.py
+++ b/mcp/ssky_server.py
@@ -7,6 +7,7 @@ import json
 import logging
 import subprocess
 import sys
+from importlib.metadata import version, PackageNotFoundError
 from fastmcp import FastMCP
 
 # Set logging level to WARNING and above for stderr output
@@ -26,8 +27,15 @@ logger = logging.getLogger("ssky_mcp_server")
 # Create FastMCP server
 mcp = FastMCP("ssky")
 
-# Set the correct version from pyproject.toml
-mcp._mcp_server.version = "0.1.2"
+# Set the correct version from installed package metadata
+def get_version():
+    try:
+        return version("ssky")
+    except PackageNotFoundError:
+        logger.warning("Could not find ssky package version, using fallback")
+        return "unknown"  # fallback version
+
+mcp._mcp_server.version = get_version()
 
 def format_success_response(data: str) -> str:
     """Format success response for MCP (expects JSON data)"""


### PR DESCRIPTION
## Summary
This PR updates the MCP server to dynamically retrieve the version from the installed ssky package metadata instead of hardcoding it.

## Changes
- Replace hardcoded version "0.1.2" with dynamic version retrieval using `importlib.metadata.version()`
- Add proper error handling with "unknown" fallback instead of outdated version number
- This ensures the MCP server always reports the correct version of the installed ssky package

## Benefits
- No need to manually update version in multiple places
- Always reflects the actual installed package version
- Works correctly in Docker containers and distributed packages

## Testing
- Tested in Docker container environment
- Verified that `importlib.metadata.version('ssky')` works correctly