### PR TITLE
Add --version flag and document special keywords

### DIFF
--- a/mcp/ssky_server.py
+++ b/mcp/ssky_server.py
@@ -82,7 +82,7 @@ def ssky_get(
     """Get posts from Bluesky timeline or specific user
     
     Args:
-        param: URI(at://...), DID(did:...), handle, or none for timeline
+        param: URI(at://...), DID(did:...), handle, "myself", or none for timeline
         limit: Number of posts to retrieve (default: 25, same as ssky command)
         delimiter: Custom delimiter string
         output_dir: Output to files in specified directory
@@ -222,9 +222,9 @@ def ssky_search(
     Args:
         query: Search query
         limit: Number of results to return (default: 25, same as ssky command)
-        author: Author handle or DID to filter by
-        since: Since timestamp (ex. 2001-01-01T00:00:00Z)
-        until: Until timestamp (ex. 2099-12-31T23:59:59Z)
+        author: Author handle, DID, or "myself" to filter by
+        since: Since timestamp (ex. 2001-01-01T00:00:00Z, "today", "yesterday")
+        until: Until timestamp (ex. 2099-12-31T23:59:59Z, "today", "yesterday")
         delimiter: Custom delimiter string
         output_dir: Output to files in specified directory
     """
@@ -280,7 +280,7 @@ def ssky_profile(handle: str, delimiter: str = "", output_dir: str = "") -> str:
     """Show user profile information
     
     Args:
-        handle: User handle (e.g., user.bsky.social)
+        handle: User handle, DID, or "myself" (e.g., user.bsky.social)
         delimiter: Custom delimiter string
         output_dir: Output to files in specified directory
     """
@@ -369,7 +369,7 @@ def ssky_follow(handle: str, delimiter: str = "", output_dir: str = "") -> str:
     """Follow a user on Bluesky
     
     Args:
-        handle: User handle or DID to follow
+        handle: User handle, DID, or "myself" to follow
         delimiter: Custom delimiter string
         output_dir: Output to files in specified directory
     """
@@ -413,7 +413,7 @@ def ssky_unfollow(handle: str, delimiter: str = "", output_dir: str = "") -> str
     """Unfollow a user on Bluesky
     
     Args:
-        handle: User handle or DID to unfollow
+        handle: User handle, DID, or "myself" to unfollow
         delimiter: Custom delimiter string
         output_dir: Output to files in specified directory
     """

--- a/src/ssky/main.py
+++ b/src/ssky/main.py
@@ -44,10 +44,10 @@ def parse():
     delete_parser.add_argument('post', type=str, help='URI(at://...)[::CID]')
 
     follow_parser = sp.add_parser('follow', formatter_class=SortingHelpFormatter, parents=[delimiter_options, format_options], help='Follow')
-    follow_parser.add_argument('name', type=str, help='Handle or DID to follow')
+    follow_parser.add_argument('name', type=str, help='Handle, DID, or "myself" to follow')
 
     get_parser = sp.add_parser('get', formatter_class=SortingHelpFormatter, parents=[delimiter_options, format_options, limit_options], help='Get posts')
-    get_parser.add_argument('target', nargs='?', type=str, default=None, metavar='PARAM', help='URI(at://...), DID(did:...), handle, or none as timeline')
+    get_parser.add_argument('target', nargs='?', type=str, default=None, metavar='PARAM', help='URI(at://...), DID(did:...), handle, "myself", or none as timeline')
 
     login_parser = sp.add_parser('login', formatter_class=SortingHelpFormatter, parents=[delimiter_options, format_options], help='Login')
     login_parser.add_argument('credentials', nargs='?', type=str, default=None, help='User credentials (handle:password)')
@@ -60,19 +60,19 @@ def parse():
     post_parser.add_argument('-r', '--reply-to', type=str, default=None, metavar='URI', help='Reply to a post')
 
     profile_parser = sp.add_parser('profile', formatter_class=SortingHelpFormatter, parents=[delimiter_options, format_options], help='Show profile')
-    profile_parser.add_argument('name', type=str, help='Handle or DID to show')
+    profile_parser.add_argument('name', type=str, help='Handle, DID, or "myself" to show')
 
     repost_parser = sp.add_parser('repost', formatter_class=SortingHelpFormatter, parents=[delimiter_options, format_options], help='Repost')
     repost_parser.add_argument('post', type=str, help='URI(at://...)[::CID]')
 
     search_parser = sp.add_parser('search', formatter_class=SortingHelpFormatter, parents=[delimiter_options, format_options, limit_options], help='Search posts')
     search_parser.add_argument('q', nargs='?', type=str, default='*', metavar='QUERY', help='Query string')
-    search_parser.add_argument('-a', '--author', type=str, default=None, metavar='ACTOR', help='Author handle or DID')
-    search_parser.add_argument('-s', '--since', type=str, default=None, metavar='TIMESTAMP', help='Since timestamp (ex. 2001-01-01T00:00:00Z, 20010101000000, 20010101)')
-    search_parser.add_argument('-u', '--until', type=str, default=None, metavar='TIMESTAMP', help='Until timestamp (ex. 2099-12-31T23:59:59Z, 20991231235959, 20991231)')
+    search_parser.add_argument('-a', '--author', type=str, default=None, metavar='ACTOR', help='Author handle, DID, or "myself"')
+    search_parser.add_argument('-s', '--since', type=str, default=None, metavar='TIMESTAMP', help='Since timestamp (ex. 2001-01-01T00:00:00Z, 20010101000000, 20010101, "today", "yesterday")')
+    search_parser.add_argument('-u', '--until', type=str, default=None, metavar='TIMESTAMP', help='Until timestamp (ex. 2099-12-31T23:59:59Z, 20991231235959, 20991231, "today", "yesterday")')
 
     unfollow_parser = sp.add_parser('unfollow', formatter_class=SortingHelpFormatter, parents=[delimiter_options, format_options], help='Unfollow')
-    unfollow_parser.add_argument('name', type=str, help='Handle or DID to unfollow')
+    unfollow_parser.add_argument('name', type=str, help='Handle, DID, or "myself" to unfollow')
 
     unrepost_parser = sp.add_parser('unrepost', formatter_class=SortingHelpFormatter, parents=[delimiter_options, format_options], help='Unrepost a post')
     unrepost_parser.add_argument('post', type=str, help='URI(at://...)[::CID]')


### PR DESCRIPTION
## Summary

This PR includes two feature implementations:

### 🔖 Issue #28: Add --version flag to display version information
- Added `--version` flag that displays the current package version
- Uses `importlib.metadata.version()` to get version dynamically from package metadata
- Displays version number only (e.g., `0.1.3`) following user preference
- Gracefully handles cases where package version cannot be determined

### 📚 Issue #27: Add documentation for special keywords in help and MCP server descriptions
- Documented special keyword `"myself"` for actor-related commands (`get`, `profile`, `follow`, `unfollow`, `search --author`)
- Documented special keywords `"today"` and `"yesterday"` for date filtering in `search --since/--until`
- Updated command-line help text to include these keywords with examples
- Updated MCP server function docstrings to mention special keyword support

## Changes Made

### Command Line Interface
- **get**: Added `"myself"` to help text
- **profile**: Added `"myself"` to help text  
- **follow/unfollow**: Added `"myself"` to help text
- **search**: Added `"myself"` for `--author`, `"today"/"yesterday"` for `--since/--until`

### MCP Server Documentation
- **ssky_get()**: Added `"myself"` keyword documentation
- **ssky_profile()**: Added `"myself"` keyword documentation
- **ssky_follow()**: Added `"myself"` keyword documentation
- **ssky_unfollow()**: Added `"myself"` keyword documentation
- **ssky_search()**: Added `"myself"`, `"today"`, `"yesterday"` keyword documentation

## Testing

- ✅ `ssky --version` displays correct version number
- ✅ Help text shows special keywords for relevant commands
- ✅ All existing functionality remains unchanged
- ✅ Special keywords work as documented (existing functionality)

## Related Issues

Closes #28
Closes #27