### PR TITLE
feat: implement consistent JSON output format with proper error handling and bump version to 0.2.0

### DIFF
--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -26,10 +26,7 @@ RUN poetry config virtualenvs.create false
 # Install dependencies and the local ssky package (including the project itself)
 RUN poetry install
 
-# Copy MCP server file to app directory
-COPY mcp/ssky_server.py /app/
-
-# Set working directory back to /app
+# Set working directory back to /app and use the installed package
 WORKDIR /app
 
 # Set environment variables (optional, can be overridden at runtime)
@@ -43,8 +40,8 @@ RUN echo '#!/bin/bash\npython3 -c "import ssky; print(\"ssky available\")" && py
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD /app/healthcheck.sh
 
-# Start MCP server
-ENTRYPOINT ["python3", "/app/ssky_server.py"]
+# Start MCP server using the installed package
+ENTRYPOINT ["python3", "-m", "ssky_mcp.server"]
 
 # Metadata
 LABEL org.opencontainers.image.title="ssky MCP Server"

--- a/mcp/Dockerfile.dev
+++ b/mcp/Dockerfile.dev
@@ -38,10 +38,7 @@ RUN ssky --help || echo "ssky command failed"
 
 # MCP dependencies are already installed via poetry (fastmcp)
 
-# Copy MCP server file to app directory
-COPY mcp/ssky_server.py /app/
-
-# Set working directory back to /app
+# Set working directory back to /app and use the installed package
 WORKDIR /app
 
 # Set environment variables (optional, can be overridden at runtime)
@@ -55,8 +52,8 @@ RUN echo '#!/bin/bash\npython3 -c "import ssky; print(\"ssky available\")" && py
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD /app/healthcheck.sh
 
-# Start MCP server
-ENTRYPOINT ["python3", "/app/ssky_server.py"]
+# Start MCP server using the installed package
+ENTRYPOINT ["python3", "-m", "ssky_mcp.server"]
 
 # Metadata
 LABEL org.opencontainers.image.title="ssky MCP Server (Local Build)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssky"
-version = "0.1.3"
+version = "0.2.0"
 description = "Simple bluesky client"
 authors = ["SimpleSkyClient Project <simpleskypclient@gmail.com>"]
 readme = "README.md"
@@ -8,7 +8,10 @@ license = "LICENSE"
 homepage = "https://github.com/simpleskyclient/ssky"
 repository = "https://github.com/simpleskyclient/ssky"
 keywords = ["bluesky", "client"]
-packages = [{include = "ssky", from = "src"}]
+packages = [
+    {include = "ssky", from = "src"},
+    {include = "ssky_mcp", from = "src"}
+]
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.14"
@@ -21,6 +24,7 @@ fastmcp = "^2.8.0"
 
 [tool.poetry.scripts]
 ssky = "ssky.main:main"
+ssky-mcp-server = "ssky_mcp.server:main"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/ssky/delete.py
+++ b/src/ssky/delete.py
@@ -1,7 +1,7 @@
 import sys
 import atproto_client
 from ssky.ssky_session import ssky_client
-from ssky.util import disjoin_uri_cid, is_joined_uri_cid
+from ssky.util import disjoin_uri_cid, is_joined_uri_cid, should_use_json_format, create_error_response, get_http_status_from_exception
 
 def delete(post, **kwargs) -> str:
     if is_joined_uri_cid(post):
@@ -16,10 +16,22 @@ def delete(post, **kwargs) -> str:
             return None
         return uri
     except atproto_client.exceptions.AtProtocolError as e:
-        if 'response' in dir(e) and e.response is not None:
-            print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-        elif str(e) is not None and len(str(e)) > 0:
-            print(f'{str(e)}', file=sys.stderr)
+        if should_use_json_format(**kwargs):
+            http_code = get_http_status_from_exception(e)
+            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+                message = e.response.content.message
+            elif str(e) is not None and len(str(e)) > 0:
+                message = str(e)
+            else:
+                message = e.__class__.__name__
+            error_response = create_error_response(message=message, http_code=http_code)
+            print(error_response)
+            return None
         else:
-            print(f'{e.__class__.__name__}', file=sys.stderr)
-        return None
+            if 'response' in dir(e) and e.response is not None:
+                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
+            elif str(e) is not None and len(str(e)) > 0:
+                print(f'{str(e)}', file=sys.stderr)
+            else:
+                print(f'{e.__class__.__name__}', file=sys.stderr)
+            return None

--- a/src/ssky/follow.py
+++ b/src/ssky/follow.py
@@ -2,32 +2,48 @@ import sys
 import atproto_client
 from ssky.profile_list import ProfileList
 from ssky.ssky_session import expand_actor, ssky_client
-from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception
+from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception, ErrorResult
 
 def follow(name, **kwargs) -> str:
     try:
         client = ssky_client()
+        if client is None:
+            error_result = ErrorResult("No valid session available", 401)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
         actor = expand_actor(name)
+        if actor is None:
+            error_result = ErrorResult("Invalid actor identifier", 400)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
         profile = client.get_profile(actor)
         client.follow(profile.did)
         return ProfileList().append(profile.did)
-    except atproto_client.exceptions.AtProtocolError as e:
+    except atproto_client.exceptions.LoginRequiredError as e:
+        error_result = ErrorResult(str(e), 401)
         if should_use_json_format(**kwargs):
-            http_code = get_http_status_from_exception(e)
-            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
-                message = e.response.content.message
-            elif str(e) is not None and len(str(e)) > 0:
-                message = str(e)
-            else:
-                message = e.__class__.__name__
-            error_response = create_error_response(message=message, http_code=http_code)
-            print(error_response)
-            return None
+            print(error_result.to_json())
         else:
-            if 'response' in dir(e) and e.response is not None:
-                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-            elif str(e) is not None and len(str(e)) > 0:
-                print(f'{str(e)}', file=sys.stderr)
-            else:
-                print(f'{e.__class__.__name__}', file=sys.stderr)
-            return None
+            print(str(error_result), file=sys.stderr)
+        return error_result
+    except atproto_client.exceptions.AtProtocolError as e:
+        http_code = get_http_status_from_exception(e)
+        if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+            message = e.response.content.message
+        elif str(e) is not None and len(str(e)) > 0:
+            message = str(e)
+        else:
+            message = e.__class__.__name__
+        
+        error_result = ErrorResult(message, http_code)
+        if should_use_json_format(**kwargs):
+            print(error_result.to_json())
+        else:
+            print(str(error_result), file=sys.stderr)
+        return error_result

--- a/src/ssky/follow.py
+++ b/src/ssky/follow.py
@@ -2,6 +2,7 @@ import sys
 import atproto_client
 from ssky.profile_list import ProfileList
 from ssky.ssky_session import expand_actor, ssky_client
+from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception
 
 def follow(name, **kwargs) -> str:
     try:
@@ -11,10 +12,22 @@ def follow(name, **kwargs) -> str:
         client.follow(profile.did)
         return ProfileList().append(profile.did)
     except atproto_client.exceptions.AtProtocolError as e:
-        if 'response' in dir(e) and e.response is not None:
-            print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-        elif str(e) is not None and len(str(e)) > 0:
-            print(f'{str(e)}', file=sys.stderr)
+        if should_use_json_format(**kwargs):
+            http_code = get_http_status_from_exception(e)
+            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+                message = e.response.content.message
+            elif str(e) is not None and len(str(e)) > 0:
+                message = str(e)
+            else:
+                message = e.__class__.__name__
+            error_response = create_error_response(message=message, http_code=http_code)
+            print(error_response)
+            return None
         else:
-            print(f'{e.__class__.__name__}', file=sys.stderr)
-        return None
+            if 'response' in dir(e) and e.response is not None:
+                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
+            elif str(e) is not None and len(str(e)) > 0:
+                print(f'{str(e)}', file=sys.stderr)
+            else:
+                print(f'{e.__class__.__name__}', file=sys.stderr)
+            return None

--- a/src/ssky/get.py
+++ b/src/ssky/get.py
@@ -2,7 +2,7 @@ import sys
 import atproto_client
 from ssky.ssky_session import expand_actor, ssky_client
 from ssky.post_data_list import PostDataList
-from ssky.util import disjoin_uri_cid, is_joined_uri_cid
+from ssky.util import disjoin_uri_cid, is_joined_uri_cid, should_use_json_format, create_error_response, get_http_status_from_exception
 
 def get_posts(client, uri, cid) -> None:
     res = client.get_posts([uri])
@@ -45,10 +45,22 @@ def get(target=None, limit=100, **kwargs) -> PostDataList:
             post_data_list = get_author_feed(client, actor, limit=limit)
         return post_data_list
     except atproto_client.exceptions.AtProtocolError as e:
-        if 'response' in dir(e) and e.response is not None:
-            print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-        elif str(e) is not None and len(str(e)) > 0:
-            print(f'{str(e)}', file=sys.stderr)
+        if should_use_json_format(**kwargs):
+            http_code = get_http_status_from_exception(e)
+            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+                message = e.response.content.message
+            elif str(e) is not None and len(str(e)) > 0:
+                message = str(e)
+            else:
+                message = e.__class__.__name__
+            error_response = create_error_response(message=message, http_code=http_code)
+            print(error_response)
+            return None
         else:
-            print(f'{e.__class__.__name__}', file=sys.stderr)
-        return None
+            if 'response' in dir(e) and e.response is not None:
+                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
+            elif str(e) is not None and len(str(e)) > 0:
+                print(f'{str(e)}', file=sys.stderr)
+            else:
+                print(f'{e.__class__.__name__}', file=sys.stderr)
+            return None

--- a/src/ssky/login.py
+++ b/src/ssky/login.py
@@ -2,6 +2,7 @@ import sys
 import atproto_client
 from ssky.profile_list import ProfileList
 from ssky.ssky_session import SskySession
+from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception
 
 def login(credentials=None, **kwargs) -> ProfileList:
     handle = None
@@ -16,10 +17,22 @@ def login(credentials=None, **kwargs) -> ProfileList:
         session.persist()
         return ProfileList().append(session.profile().did)
     except atproto_client.exceptions.AtProtocolError as e:
-        if 'response' in dir(e) and e.response is not None:
-            print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-        elif str(e) is not None and len(str(e)) > 0:
-            print(f'{str(e)}', file=sys.stderr)
+        if should_use_json_format(**kwargs):
+            http_code = get_http_status_from_exception(e)
+            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+                message = e.response.content.message
+            elif str(e) is not None and len(str(e)) > 0:
+                message = str(e)
+            else:
+                message = e.__class__.__name__
+            error_response = create_error_response(message=message, http_code=http_code)
+            print(error_response)
+            return None
         else:
-            print(f'{e.__class__.__name__}', file=sys.stderr)
-        return None
+            if 'response' in dir(e) and e.response is not None:
+                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
+            elif str(e) is not None and len(str(e)) > 0:
+                print(f'{str(e)}', file=sys.stderr)
+            else:
+                print(f'{e.__class__.__name__}', file=sys.stderr)
+            return None

--- a/src/ssky/login.py
+++ b/src/ssky/login.py
@@ -1,22 +1,33 @@
 import sys
+from typing import Union
 import atproto_client
 from ssky.profile_list import ProfileList
 from ssky.ssky_session import SskySession
-from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception
+from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception, ErrorResult
 
-def login(credentials=None, **kwargs) -> ProfileList:
+def login(credentials=None, **kwargs) -> ProfileList | ErrorResult:
     handle = None
     password = None
     
     # Parse credentials if provided
     if credentials is not None:
         if not credentials.strip():  # Empty or whitespace-only string
-            return None
+            error_result = ErrorResult("Empty credentials provided", 400)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
         if ':' in credentials:
             handle, password = credentials.split(':', 1)
         else:
             # Invalid format - no colon separator
-            return None
+            error_result = ErrorResult("Invalid credential format - expected 'handle:password'", 400)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
     
     try:
         session = SskySession(handle=handle, password=password)
@@ -25,32 +36,43 @@ def login(credentials=None, **kwargs) -> ProfileList:
         # Check if profile is available
         profile = session.profile()
         if profile is None or not hasattr(profile, 'did') or profile.did is None:
-            print("Profile not available after login", file=sys.stderr)
-            return None
+            error_result = ErrorResult("Profile not available after login", 500)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
         
         return ProfileList().append(profile.did)
         
-    except atproto_client.exceptions.AtProtocolError as e:
+    except atproto_client.exceptions.LoginRequiredError as e:
+        error_result = ErrorResult(str(e), 401)
         if should_use_json_format(**kwargs):
-            http_code = get_http_status_from_exception(e)
-            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
-                message = e.response.content.message
-            elif str(e) is not None and len(str(e)) > 0:
-                message = str(e)
-            else:
-                message = e.__class__.__name__
-            error_response = create_error_response(message=message, http_code=http_code)
-            print(error_response)
-            return None
+            print(error_result.to_json())
         else:
-            if 'response' in dir(e) and e.response is not None:
-                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-            elif str(e) is not None and len(str(e)) > 0:
-                print(f'{str(e)}', file=sys.stderr)
-            else:
-                print(f'{e.__class__.__name__}', file=sys.stderr)
-            return None
+            print(str(error_result), file=sys.stderr)
+        return error_result
+        
+    except atproto_client.exceptions.AtProtocolError as e:
+        http_code = get_http_status_from_exception(e)
+        if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+            message = e.response.content.message
+        elif str(e) is not None and len(str(e)) > 0:
+            message = str(e)
+        else:
+            message = e.__class__.__name__
+        
+        error_result = ErrorResult(message, http_code)
+        if should_use_json_format(**kwargs):
+            print(error_result.to_json())
+        else:
+            print(str(error_result), file=sys.stderr)
+        return error_result
     except Exception as e:
         # Catch any other unexpected exceptions
-        print(f"Unexpected error during login: {str(e)}", file=sys.stderr)
-        return None
+        error_result = ErrorResult(f"Unexpected error during login: {str(e)}", 500)
+        if should_use_json_format(**kwargs):
+            print(error_result.to_json())
+        else:
+            print(str(error_result), file=sys.stderr)
+        return error_result

--- a/src/ssky/main.py
+++ b/src/ssky/main.py
@@ -97,7 +97,12 @@ def execute(subcommand, args) -> bool:
         else:
             from ssky.post_data_list import PostDataList
             from ssky.profile_list import ProfileList
-            if type(result) is PostDataList or type(result) is ProfileList:
+            from ssky.util import ErrorResult
+            
+            if isinstance(result, ErrorResult):
+                # Error result - return failure status, output already printed by function
+                return False
+            elif type(result) is PostDataList or type(result) is ProfileList:
                 result.print(format=args.format, output=args.output, delimiter=args.delimiter)
             elif type(result) is list:
                 if type(result[0]) is list:

--- a/src/ssky/post.py
+++ b/src/ssky/post.py
@@ -7,7 +7,7 @@ from bs4 import BeautifulSoup
 import requests
 from ssky.ssky_session import ssky_client
 from ssky.post_data_list import PostDataList
-from ssky.util import disjoin_uri_cid, is_joined_uri_cid
+from ssky.util import disjoin_uri_cid, is_joined_uri_cid, should_use_json_format, create_error_response, get_http_status_from_exception
 
 def get_card(links):
     title = None
@@ -329,10 +329,22 @@ def post(message=None, dry=False, image=[], quote=None, reply_to=None, **kwargs)
 
         return PostDataList().append(post)
     except atproto_client.exceptions.AtProtocolError as e:
-        if 'response' in dir(e) and e.response is not None:
-            print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-        elif str(e) is not None and len(str(e)) > 0:
-            print(f'{str(e)}', file=sys.stderr)
+        if should_use_json_format(**kwargs):
+            http_code = get_http_status_from_exception(e)
+            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+                message = e.response.content.message
+            elif str(e) is not None and len(str(e)) > 0:
+                message = str(e)
+            else:
+                message = e.__class__.__name__
+            error_response = create_error_response(message=message, http_code=http_code)
+            print(error_response)
+            return None
         else:
-            print(f'{e.__class__.__name__}', file=sys.stderr)
-        return None
+            if 'response' in dir(e) and e.response is not None:
+                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
+            elif str(e) is not None and len(str(e)) > 0:
+                print(f'{str(e)}', file=sys.stderr)
+            else:
+                print(f'{e.__class__.__name__}', file=sys.stderr)
+            return None

--- a/src/ssky/profile.py
+++ b/src/ssky/profile.py
@@ -2,6 +2,7 @@ import sys
 import atproto_client
 from ssky.profile_list import ProfileList
 from ssky.ssky_session import expand_actor, ssky_client
+from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception
 
 def profile(name, **kwargs) -> ProfileList:
     try:
@@ -11,10 +12,22 @@ def profile(name, **kwargs) -> ProfileList:
             return None
         return ProfileList().append(profile.did)
     except atproto_client.exceptions.AtProtocolError as e:
-        if 'response' in dir(e) and e.response is not None:
-            print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-        elif str(e) is not None and len(str(e)) > 0:
-            print(f'{str(e)}', file=sys.stderr)
+        if should_use_json_format(**kwargs):
+            http_code = get_http_status_from_exception(e)
+            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+                message = e.response.content.message
+            elif str(e) is not None and len(str(e)) > 0:
+                message = str(e)
+            else:
+                message = e.__class__.__name__
+            error_response = create_error_response(message=message, http_code=http_code)
+            print(error_response)
+            return None
         else:
-            print(f'{e.__class__.__name__}', file=sys.stderr)
-        return None
+            if 'response' in dir(e) and e.response is not None:
+                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
+            elif str(e) is not None and len(str(e)) > 0:
+                print(f'{str(e)}', file=sys.stderr)
+            else:
+                print(f'{e.__class__.__name__}', file=sys.stderr)
+            return None

--- a/src/ssky/profile.py
+++ b/src/ssky/profile.py
@@ -4,9 +4,25 @@ from ssky.profile_list import ProfileList
 from ssky.ssky_session import expand_actor, ssky_client
 from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception, ErrorResult
 
-def profile(name, **kwargs) -> ProfileList:
+def profile(name, **kwargs) -> ProfileList | ErrorResult:
     try:
-        profile = ssky_client().get_profile(expand_actor(name))
+        client = ssky_client()
+        if client is None:
+            error_result = ErrorResult("No valid session available", 401)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
+        actor = expand_actor(name)
+        if actor is None:
+            error_result = ErrorResult("Invalid actor identifier", 400)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
+        profile = client.get_profile(actor)
         if profile is None:
             error_result = ErrorResult("Profile not found", 404)
             if should_use_json_format(**kwargs):
@@ -15,6 +31,13 @@ def profile(name, **kwargs) -> ProfileList:
                 print(str(error_result), file=sys.stderr)
             return error_result
         return ProfileList().append(profile.did)
+    except atproto_client.exceptions.LoginRequiredError as e:
+        error_result = ErrorResult(str(e), 401)
+        if should_use_json_format(**kwargs):
+            print(error_result.to_json())
+        else:
+            print(str(error_result), file=sys.stderr)
+        return error_result
     except atproto_client.exceptions.AtProtocolError as e:
         http_code = get_http_status_from_exception(e)
         if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):

--- a/src/ssky/profile.py
+++ b/src/ssky/profile.py
@@ -2,32 +2,31 @@ import sys
 import atproto_client
 from ssky.profile_list import ProfileList
 from ssky.ssky_session import expand_actor, ssky_client
-from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception
+from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception, ErrorResult
 
 def profile(name, **kwargs) -> ProfileList:
     try:
         profile = ssky_client().get_profile(expand_actor(name))
         if profile is None:
-            print(f'Profile not found', file=sys.stderr)
-            return None
+            error_result = ErrorResult("Profile not found", 404)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
         return ProfileList().append(profile.did)
     except atproto_client.exceptions.AtProtocolError as e:
-        if should_use_json_format(**kwargs):
-            http_code = get_http_status_from_exception(e)
-            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
-                message = e.response.content.message
-            elif str(e) is not None and len(str(e)) > 0:
-                message = str(e)
-            else:
-                message = e.__class__.__name__
-            error_response = create_error_response(message=message, http_code=http_code)
-            print(error_response)
-            return None
+        http_code = get_http_status_from_exception(e)
+        if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+            message = e.response.content.message
+        elif str(e) is not None and len(str(e)) > 0:
+            message = str(e)
         else:
-            if 'response' in dir(e) and e.response is not None:
-                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-            elif str(e) is not None and len(str(e)) > 0:
-                print(f'{str(e)}', file=sys.stderr)
-            else:
-                print(f'{e.__class__.__name__}', file=sys.stderr)
-            return None
+            message = e.__class__.__name__
+        
+        error_result = ErrorResult(message, http_code)
+        if should_use_json_format(**kwargs):
+            print(error_result.to_json())
+        else:
+            print(str(error_result), file=sys.stderr)
+        return error_result

--- a/src/ssky/repost.py
+++ b/src/ssky/repost.py
@@ -2,9 +2,9 @@ import sys
 import atproto_client
 from ssky.post_data_list import PostDataList
 from ssky.ssky_session import ssky_client
-from ssky.util import disjoin_uri_cid, is_joined_uri_cid, join_uri_cid, should_use_json_format, create_error_response, get_http_status_from_exception
+from ssky.util import disjoin_uri_cid, is_joined_uri_cid, join_uri_cid, should_use_json_format, create_error_response, get_http_status_from_exception, ErrorResult
 
-def repost(post, **kwargs) -> str:
+def repost(post, **kwargs) -> PostDataList | ErrorResult:
     if is_joined_uri_cid(post):
         source_uri, source_cid = disjoin_uri_cid(post)
     else:
@@ -12,33 +12,44 @@ def repost(post, **kwargs) -> str:
         source_cid = None
 
     try:
+        client = ssky_client()
+        if client is None:
+            error_result = ErrorResult("No valid session available", 401)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
+        
         post_data_list = PostDataList()
-        sources = ssky_client().get_posts([source_uri])
+        sources = client.get_posts([source_uri])
         for source_post in sources.posts:
             if source_post.uri == source_uri and (source_cid is None or source_post.cid == source_cid):
                 post_data_list.append(source_post)
                 source_cid = source_post.cid
                 break
 
-        ssky_client().repost(source_uri, source_cid)
+        client.repost(source_uri, source_cid)
         return post_data_list
-    except atproto_client.exceptions.AtProtocolError as e:
+    except atproto_client.exceptions.LoginRequiredError as e:
+        error_result = ErrorResult(str(e), 401)
         if should_use_json_format(**kwargs):
-            http_code = get_http_status_from_exception(e)
-            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
-                message = e.response.content.message
-            elif str(e) is not None and len(str(e)) > 0:
-                message = str(e)
-            else:
-                message = e.__class__.__name__
-            error_response = create_error_response(message=message, http_code=http_code)
-            print(error_response)
-            return None
+            print(error_result.to_json())
         else:
-            if 'response' in dir(e) and e.response is not None:
-                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-            elif str(e) is not None and len(str(e)) > 0:
-                print(f'{str(e)}', file=sys.stderr)
-            else:
-                print(f'{e.__class__.__name__}', file=sys.stderr)
-            return None
+            print(str(error_result), file=sys.stderr)
+        return error_result
+    except atproto_client.exceptions.AtProtocolError as e:
+        http_code = get_http_status_from_exception(e)
+        if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+            message = e.response.content.message
+        elif str(e) is not None and len(str(e)) > 0:
+            message = str(e)
+        else:
+            message = e.__class__.__name__
+        
+        error_result = ErrorResult(message, http_code)
+        if should_use_json_format(**kwargs):
+            print(error_result.to_json())
+        else:
+            print(str(error_result), file=sys.stderr)
+        return error_result

--- a/src/ssky/repost.py
+++ b/src/ssky/repost.py
@@ -2,7 +2,7 @@ import sys
 import atproto_client
 from ssky.post_data_list import PostDataList
 from ssky.ssky_session import ssky_client
-from ssky.util import disjoin_uri_cid, is_joined_uri_cid, join_uri_cid
+from ssky.util import disjoin_uri_cid, is_joined_uri_cid, join_uri_cid, should_use_json_format, create_error_response, get_http_status_from_exception
 
 def repost(post, **kwargs) -> str:
     if is_joined_uri_cid(post):
@@ -23,10 +23,22 @@ def repost(post, **kwargs) -> str:
         ssky_client().repost(source_uri, source_cid)
         return post_data_list
     except atproto_client.exceptions.AtProtocolError as e:
-        if 'response' in dir(e) and e.response is not None:
-            print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-        elif str(e) is not None and len(str(e)) > 0:
-            print(f'{str(e)}', file=sys.stderr)
+        if should_use_json_format(**kwargs):
+            http_code = get_http_status_from_exception(e)
+            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+                message = e.response.content.message
+            elif str(e) is not None and len(str(e)) > 0:
+                message = str(e)
+            else:
+                message = e.__class__.__name__
+            error_response = create_error_response(message=message, http_code=http_code)
+            print(error_response)
+            return None
         else:
-            print(f'{e.__class__.__name__}', file=sys.stderr)
-        return None
+            if 'response' in dir(e) and e.response is not None:
+                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
+            elif str(e) is not None and len(str(e)) > 0:
+                print(f'{str(e)}', file=sys.stderr)
+            else:
+                print(f'{e.__class__.__name__}', file=sys.stderr)
+            return None

--- a/src/ssky/search.py
+++ b/src/ssky/search.py
@@ -5,7 +5,7 @@ from atproto import models
 import atproto_client
 from ssky.ssky_session import expand_actor, ssky_client
 from ssky.post_data_list import PostDataList
-from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception
+from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception, ErrorResult
 
 def expand_datetime(dt: str) -> str:
     if dt:
@@ -29,7 +29,15 @@ def search(q='*', author=None, since=None, until=None, limit=100, **kwargs) -> P
     until = expand_datetime(until)
 
     try:
-        res = ssky_client().app.bsky.feed.search_posts(
+        client = ssky_client()
+        if client is None:
+            error_result = ErrorResult("No valid session available", 401)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
+        res = client.app.bsky.feed.search_posts(
             models.AppBskyFeedSearchPosts.Params(
                 author=expand_actor(author),
                 limit=limit,
@@ -45,22 +53,17 @@ def search(q='*', author=None, since=None, until=None, limit=100, **kwargs) -> P
                 post_data_list.append(post)
         return post_data_list
     except atproto_client.exceptions.AtProtocolError as e:
-        if should_use_json_format(**kwargs):
-            http_code = get_http_status_from_exception(e)
-            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
-                message = e.response.content.message
-            elif str(e) is not None and len(str(e)) > 0:
-                message = str(e)
-            else:
-                message = e.__class__.__name__
-            error_response = create_error_response(message=message, http_code=http_code)
-            print(error_response)
-            return None
+        http_code = get_http_status_from_exception(e)
+        if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+            message = e.response.content.message
+        elif str(e) is not None and len(str(e)) > 0:
+            message = str(e)
         else:
-            if 'response' in dir(e) and e.response is not None:
-                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-            elif str(e) is not None and len(str(e)) > 0:
-                print(f'{str(e)}', file=sys.stderr)
-            else:
-                print(f'{e.__class__.__name__}', file=sys.stderr)
-            return None
+            message = e.__class__.__name__
+        
+        error_result = ErrorResult(message, http_code)
+        if should_use_json_format(**kwargs):
+            print(error_result.to_json())
+        else:
+            print(str(error_result), file=sys.stderr)
+        return error_result

--- a/src/ssky/unfollow.py
+++ b/src/ssky/unfollow.py
@@ -2,6 +2,7 @@ import sys
 import atproto_client
 from ssky.profile_list import ProfileList
 from ssky.ssky_session import expand_actor, ssky_client, ssky_profile
+from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception
 
 def unfollow(name, **kwargs) -> ProfileList:
     try:
@@ -19,10 +20,22 @@ def unfollow(name, **kwargs) -> ProfileList:
         print(f'You are not following {actor}', file=sys.stderr)
         return None
     except atproto_client.exceptions.AtProtocolError as e:
-        if 'response' in dir(e) and e.response is not None:
-            print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-        elif str(e) is not None and len(str(e)) > 0:
-            print(f'{str(e)}', file=sys.stderr)
+        if should_use_json_format(**kwargs):
+            http_code = get_http_status_from_exception(e)
+            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+                message = e.response.content.message
+            elif str(e) is not None and len(str(e)) > 0:
+                message = str(e)
+            else:
+                message = e.__class__.__name__
+            error_response = create_error_response(message=message, http_code=http_code)
+            print(error_response)
+            return None
         else:
-            print(f'{e.__class__.__name__}', file=sys.stderr)
-        return None
+            if 'response' in dir(e) and e.response is not None:
+                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
+            elif str(e) is not None and len(str(e)) > 0:
+                print(f'{str(e)}', file=sys.stderr)
+            else:
+                print(f'{e.__class__.__name__}', file=sys.stderr)
+            return None

--- a/src/ssky/unfollow.py
+++ b/src/ssky/unfollow.py
@@ -2,40 +2,73 @@ import sys
 import atproto_client
 from ssky.profile_list import ProfileList
 from ssky.ssky_session import expand_actor, ssky_client, ssky_profile
-from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception
+from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception, ErrorResult
 
 def unfollow(name, **kwargs) -> ProfileList:
     try:
-        res = ssky_client().get_follows(ssky_profile().did)
+        client = ssky_client()
+        if client is None:
+            error_result = ErrorResult("No valid session available", 401)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
+        profile = ssky_profile()
+        if profile is None:
+            error_result = ErrorResult("Profile not available", 401)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
+        res = client.get_follows(profile.did)
         actor = expand_actor(name)
+        if actor is None:
+            error_result = ErrorResult("Invalid actor identifier", 400)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
         for follow in res.follows:
             if follow.did == actor or follow.handle == actor:
                 if follow.viewer.following:
-                    status = ssky_client().unfollow(follow.viewer.following)
+                    status = client.unfollow(follow.viewer.following)
                     if status is False:
-                        print('Failed to unfollow', file=sys.stderr)
-                        return None
+                        error_result = ErrorResult("Failed to unfollow", 500)
+                        if should_use_json_format(**kwargs):
+                            print(error_result.to_json())
+                        else:
+                            print(str(error_result), file=sys.stderr)
+                        return error_result
                     else:
                         return ProfileList().append(follow.did)
-        print(f'You are not following {actor}', file=sys.stderr)
-        return None
-    except atproto_client.exceptions.AtProtocolError as e:
+        error_result = ErrorResult(f"You are not following {actor}", 404)
         if should_use_json_format(**kwargs):
-            http_code = get_http_status_from_exception(e)
-            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
-                message = e.response.content.message
-            elif str(e) is not None and len(str(e)) > 0:
-                message = str(e)
-            else:
-                message = e.__class__.__name__
-            error_response = create_error_response(message=message, http_code=http_code)
-            print(error_response)
-            return None
+            print(error_result.to_json())
         else:
-            if 'response' in dir(e) and e.response is not None:
-                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-            elif str(e) is not None and len(str(e)) > 0:
-                print(f'{str(e)}', file=sys.stderr)
-            else:
-                print(f'{e.__class__.__name__}', file=sys.stderr)
-            return None
+            print(str(error_result), file=sys.stderr)
+        return error_result
+    except atproto_client.exceptions.LoginRequiredError as e:
+        error_result = ErrorResult(str(e), 401)
+        if should_use_json_format(**kwargs):
+            print(error_result.to_json())
+        else:
+            print(str(error_result), file=sys.stderr)
+        return error_result
+    except atproto_client.exceptions.AtProtocolError as e:
+        http_code = get_http_status_from_exception(e)
+        if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+            message = e.response.content.message
+        elif str(e) is not None and len(str(e)) > 0:
+            message = str(e)
+        else:
+            message = e.__class__.__name__
+        
+        error_result = ErrorResult(message, http_code)
+        if should_use_json_format(**kwargs):
+            print(error_result.to_json())
+        else:
+            print(str(error_result), file=sys.stderr)
+        return error_result

--- a/src/ssky/unrepost.py
+++ b/src/ssky/unrepost.py
@@ -2,9 +2,9 @@ import sys
 import atproto_client
 from ssky.post_data_list import PostDataList
 from ssky.ssky_session import ssky_client
-from ssky.util import disjoin_uri_cid, is_joined_uri_cid, should_use_json_format, create_error_response, get_http_status_from_exception
+from ssky.util import disjoin_uri_cid, is_joined_uri_cid, should_use_json_format, create_error_response, get_http_status_from_exception, ErrorResult
 
-def unrepost(post, **kwargs) -> str:
+def unrepost(post, **kwargs) -> PostDataList | ErrorResult:
     if is_joined_uri_cid(post):
         source_uri, source_cid = disjoin_uri_cid(post)
     else:
@@ -12,8 +12,17 @@ def unrepost(post, **kwargs) -> str:
         source_cid = None
 
     try:
+        client = ssky_client()
+        if client is None:
+            error_result = ErrorResult("No valid session available", 401)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
+        
         post_data_list = PostDataList()
-        sources = ssky_client().get_posts([source_uri])
+        sources = client.get_posts([source_uri])
         repost_uri = None
         for source_post in sources.posts:
             if source_post.uri == source_uri and (source_cid is None or source_post.cid == source_cid):
@@ -22,32 +31,42 @@ def unrepost(post, **kwargs) -> str:
                 break
 
         if repost_uri is None:
-            print(f'Post not found', file=sys.stderr)
-            return None
+            error_result = ErrorResult("Post not found", 404)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
 
-        status = ssky_client().unrepost(repost_uri)
+        status = client.unrepost(repost_uri)
         if status is False:
-            print('Failed to unrepost', file=sys.stderr)
-            return None
+            error_result = ErrorResult("Failed to unrepost", 500)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
 
         return post_data_list
-    except atproto_client.exceptions.AtProtocolError as e:
+    except atproto_client.exceptions.LoginRequiredError as e:
+        error_result = ErrorResult(str(e), 401)
         if should_use_json_format(**kwargs):
-            http_code = get_http_status_from_exception(e)
-            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
-                message = e.response.content.message
-            elif str(e) is not None and len(str(e)) > 0:
-                message = str(e)
-            else:
-                message = e.__class__.__name__
-            error_response = create_error_response(message=message, http_code=http_code)
-            print(error_response)
-            return None
+            print(error_result.to_json())
         else:
-            if 'response' in dir(e) and e.response is not None:
-                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-            elif str(e) is not None and len(str(e)) > 0:
-                print(f'{str(e)}', file=sys.stderr)
-            else:
-                print(f'{e.__class__.__name__}', file=sys.stderr)
-            return None
+            print(str(error_result), file=sys.stderr)
+        return error_result
+    except atproto_client.exceptions.AtProtocolError as e:
+        http_code = get_http_status_from_exception(e)
+        if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+            message = e.response.content.message
+        elif str(e) is not None and len(str(e)) > 0:
+            message = str(e)
+        else:
+            message = e.__class__.__name__
+        
+        error_result = ErrorResult(message, http_code)
+        if should_use_json_format(**kwargs):
+            print(error_result.to_json())
+        else:
+            print(str(error_result), file=sys.stderr)
+        return error_result

--- a/src/ssky/unrepost.py
+++ b/src/ssky/unrepost.py
@@ -2,7 +2,7 @@ import sys
 import atproto_client
 from ssky.post_data_list import PostDataList
 from ssky.ssky_session import ssky_client
-from ssky.util import disjoin_uri_cid, is_joined_uri_cid
+from ssky.util import disjoin_uri_cid, is_joined_uri_cid, should_use_json_format, create_error_response, get_http_status_from_exception
 
 def unrepost(post, **kwargs) -> str:
     if is_joined_uri_cid(post):
@@ -32,10 +32,22 @@ def unrepost(post, **kwargs) -> str:
 
         return post_data_list
     except atproto_client.exceptions.AtProtocolError as e:
-        if 'response' in dir(e) and e.response is not None:
-            print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-        elif str(e) is not None and len(str(e)) > 0:
-            print(f'{str(e)}', file=sys.stderr)
+        if should_use_json_format(**kwargs):
+            http_code = get_http_status_from_exception(e)
+            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+                message = e.response.content.message
+            elif str(e) is not None and len(str(e)) > 0:
+                message = str(e)
+            else:
+                message = e.__class__.__name__
+            error_response = create_error_response(message=message, http_code=http_code)
+            print(error_response)
+            return None
         else:
-            print(f'{e.__class__.__name__}', file=sys.stderr)
-        return None
+            if 'response' in dir(e) and e.response is not None:
+                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
+            elif str(e) is not None and len(str(e)) > 0:
+                print(f'{str(e)}', file=sys.stderr)
+            else:
+                print(f'{e.__class__.__name__}', file=sys.stderr)
+            return None

--- a/src/ssky/user.py
+++ b/src/ssky/user.py
@@ -3,6 +3,7 @@ from atproto import models
 import atproto_client
 from ssky.profile_list import ProfileList
 from ssky.ssky_session import ssky_client
+from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception
 
 def user(q, limit=100, **kwargs) -> ProfileList:
     try:
@@ -18,10 +19,22 @@ def user(q, limit=100, **kwargs) -> ProfileList:
             actor_list.append(actor.did)
         return actor_list
     except atproto_client.exceptions.AtProtocolError as e:
-        if 'response' in dir(e) and e.response is not None:
-            print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-        elif str(e) is not None and len(str(e)) > 0:
-            print(f'{str(e)}', file=sys.stderr)
+        if should_use_json_format(**kwargs):
+            http_code = get_http_status_from_exception(e)
+            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+                message = e.response.content.message
+            elif str(e) is not None and len(str(e)) > 0:
+                message = str(e)
+            else:
+                message = e.__class__.__name__
+            error_response = create_error_response(message=message, http_code=http_code)
+            print(error_response)
+            return None
         else:
-            print(f'{e.__class__.__name__}', file=sys.stderr)
-        return None
+            if 'response' in dir(e) and e.response is not None:
+                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
+            elif str(e) is not None and len(str(e)) > 0:
+                print(f'{str(e)}', file=sys.stderr)
+            else:
+                print(f'{e.__class__.__name__}', file=sys.stderr)
+            return None

--- a/src/ssky/user.py
+++ b/src/ssky/user.py
@@ -3,11 +3,19 @@ from atproto import models
 import atproto_client
 from ssky.profile_list import ProfileList
 from ssky.ssky_session import ssky_client
-from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception
+from ssky.util import should_use_json_format, create_error_response, get_http_status_from_exception, ErrorResult
 
 def user(q, limit=100, **kwargs) -> ProfileList:
     try:
-        res = ssky_client().app.bsky.actor.search_actors(
+        client = ssky_client()
+        if client is None:
+            error_result = ErrorResult("No valid session available", 401)
+            if should_use_json_format(**kwargs):
+                print(error_result.to_json())
+            else:
+                print(str(error_result), file=sys.stderr)
+            return error_result
+        res = client.app.bsky.actor.search_actors(
             models.AppBskyActorSearchActors.Params(
                 limit=limit,
                 q=q
@@ -19,22 +27,17 @@ def user(q, limit=100, **kwargs) -> ProfileList:
             actor_list.append(actor.did)
         return actor_list
     except atproto_client.exceptions.AtProtocolError as e:
-        if should_use_json_format(**kwargs):
-            http_code = get_http_status_from_exception(e)
-            if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
-                message = e.response.content.message
-            elif str(e) is not None and len(str(e)) > 0:
-                message = str(e)
-            else:
-                message = e.__class__.__name__
-            error_response = create_error_response(message=message, http_code=http_code)
-            print(error_response)
-            return None
+        http_code = get_http_status_from_exception(e)
+        if 'response' in dir(e) and e.response is not None and hasattr(e.response, 'content') and hasattr(e.response.content, 'message'):
+            message = e.response.content.message
+        elif str(e) is not None and len(str(e)) > 0:
+            message = str(e)
         else:
-            if 'response' in dir(e) and e.response is not None:
-                print(f'{e.response.status_code} {e.response.content.message}', file=sys.stderr)
-            elif str(e) is not None and len(str(e)) > 0:
-                print(f'{str(e)}', file=sys.stderr)
-            else:
-                print(f'{e.__class__.__name__}', file=sys.stderr)
-            return None
+            message = e.__class__.__name__
+        
+        error_result = ErrorResult(message, http_code)
+        if should_use_json_format(**kwargs):
+            print(error_result.to_json())
+        else:
+            print(str(error_result), file=sys.stderr)
+        return error_result

--- a/src/ssky/util.py
+++ b/src/ssky/util.py
@@ -1,7 +1,29 @@
 import json
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional
+
+class ErrorResult:
+    """Error result container that holds error information."""
+    
+    def __init__(self, message: str, http_code: int = 500, data: Any = None):
+        self.message = message
+        self.http_code = http_code
+        self.data = data
+        self.timestamp = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+        self.is_error = True
+    
+    def to_json(self) -> str:
+        """Convert to JSON string."""
+        return create_error_response(
+            message=self.message,
+            http_code=self.http_code,
+            data=self.data
+        )
+    
+    def __str__(self) -> str:
+        """String representation for stderr output."""
+        return f"{self.http_code} {self.message}"
 
 def summarize(source, length_max=0):
     if source is None:
@@ -42,7 +64,7 @@ def create_json_response(
         JSON string with consistent format
     """
     if timestamp is None:
-        timestamp = datetime.utcnow().isoformat() + 'Z'
+        timestamp = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
     
     response = {
         "status": status,

--- a/src/ssky_mcp/__init__.py
+++ b/src/ssky_mcp/__init__.py
@@ -1,0 +1,5 @@
+"""
+Ssky MCP (Model Context Protocol) Server Package
+
+This package provides MCP server functionality for the ssky Bluesky client.
+"""

--- a/tests/common.py
+++ b/tests/common.py
@@ -17,8 +17,7 @@ def setup(envs_to_delete=[], no_session_file=False, interval=0):
         if os.path.exists(os.path.expanduser('~/.ssky')):
             os.remove(os.path.expanduser('~/.ssky'))
 
-def teardown():
-    pass
+
 
 # New utilities for session management optimization
 
@@ -50,11 +49,12 @@ def setup_with_session_copy(master_session_path, envs_to_delete=[]):
         session_path = os.path.expanduser('~/.ssky')
         shutil.copy2(master_session_path, session_path)
 
-def cleanup_session_file():
-    """Clean up session file"""
-    session_path = os.path.expanduser('~/.ssky')
-    if os.path.exists(session_path):
-        os.remove(session_path)
+
+
+def has_credentials():
+    """Check if SSKY_USER credentials are available"""
+    load_dotenv('tests/.env')
+    return bool(os.environ.get('SSKY_USER'))
 
 def create_mock_atproto_client():
     """Create mock atproto client for testing without API calls"""
@@ -66,4 +66,208 @@ def create_mock_atproto_client():
     mock_client.login.return_value = mock_profile
     mock_client.export_session_string.return_value = '{"test": "session_data"}'
     
+    # Mock feed responses with iterable feed lists
+    mock_feed_post = Mock()
+    mock_feed_post.post = Mock()
+    mock_feed_post.post.uri = "at://test.user/app.bsky.feed.post/test123"
+    mock_feed_post.post.cid = "testcid123"
+    
+    # Timeline response
+    mock_timeline_response = Mock()
+    mock_timeline_response.feed = [mock_feed_post]
+    mock_client.get_timeline.return_value = mock_timeline_response
+    
+    # Author feed response
+    mock_author_feed_response = Mock()
+    mock_author_feed_response.feed = [mock_feed_post]
+    mock_client.get_author_feed.return_value = mock_author_feed_response
+    
+    # Posts response - default post without viewer info
+    mock_post = Mock()
+    mock_post.uri = "at://test.user/app.bsky.feed.post/test123"
+    mock_post.cid = "testcid123"
+    mock_post.viewer = Mock()
+    mock_post.viewer.repost = None  # Default: not reposted
+    mock_posts_response = Mock()
+    mock_posts_response.posts = [mock_post]
+    
+    # Mock follows response for unfollow functionality
+    mock_follow = Mock()
+    mock_follow.did = "did:plc:test123"
+    mock_follow.handle = "test.bsky.social"
+    mock_follow.viewer = Mock()
+    mock_follow.viewer.following = "at://test.user/app.bsky.graph.follow/test123"
+    
+    mock_follows_response = Mock()
+    mock_follows_response.follows = [mock_follow]
+    mock_client.get_follows.return_value = mock_follows_response
+    
+    # Mock profile response for follow functionality
+    mock_profile_response = Mock()
+    mock_profile_response.did = "did:plc:test123"
+    mock_client.get_profile.return_value = mock_profile_response
+    
+    # Mock send_post response with string URI - use a simple object instead of Mock
+    class MockSendPostResponse:
+        def __init__(self):
+            self.uri = "at://test.user/app.bsky.feed.post/test123"
+            self.cid = "testcid123"
+    
+    mock_send_post_response = MockSendPostResponse()
+    mock_client.send_post.return_value = mock_send_post_response
+    mock_client.send_images.return_value = mock_send_post_response
+    
+    # Mock repost with viewer info
+    mock_repost_post = Mock()
+    mock_repost_post.uri = "at://test.user/app.bsky.feed.post/test123"
+    mock_repost_post.cid = "testcid123"
+    mock_repost_post.viewer = Mock()
+    mock_repost_post.viewer.repost = "at://test.user/app.bsky.feed.repost/test123"
+    
+    mock_repost_posts_response = Mock()
+    mock_repost_posts_response.posts = [mock_repost_post]
+    
+    # For repost/unrepost, we need to return different responses
+    # Default to the basic version (not reposted), tests can override as needed
+    mock_client.get_posts.return_value = mock_posts_response
+    
+    # Mock search functionality
+    mock_author = Mock()
+    mock_author.did = "did:plc:search123"
+    mock_author.handle = "search.bsky.social"
+    mock_author.display_name = "Search User"
+    mock_author.avatar = "https://example.com/avatar.jpg"
+    
+    mock_record = Mock()
+    mock_record.text = "Search result post"
+    mock_record.created_at = "2023-01-01T00:00:00.000Z"
+    mock_record.facets = None
+    
+    mock_search_post = Mock()
+    mock_search_post.uri = "at://test.user/app.bsky.feed.post/search123"
+    mock_search_post.cid = "searchcid123"
+    mock_search_post.author = mock_author
+    mock_search_post.record = mock_record
+    mock_search_post.indexed_at = "2023-01-01T01:00:00.000Z"
+    mock_search_post.reply_count = 0
+    mock_search_post.repost_count = 0
+    mock_search_post.like_count = 0
+    mock_search_post.viewer = None
+    
+    # Ensure URI and CID can be used in string operations
+    mock_search_post.__str__ = lambda: "at://test.user/app.bsky.feed.post/search123"
+    
+    mock_search_response = Mock()
+    mock_search_response.posts = [mock_search_post]
+    mock_client.app.bsky.feed.search_posts.return_value = mock_search_response
+    
     return mock_client, mock_profile
+
+def create_mock_ssky_session():
+    """Create mock SskySession for testing without API calls or session files"""
+    from unittest.mock import Mock
+    
+    # Mock profile
+    mock_profile = Mock()
+    mock_profile.did = "did:plc:test123456789"
+    mock_profile.handle = "test.bsky.social"
+    mock_profile.display_name = "Test User"
+    
+    # Mock client
+    mock_client = Mock()
+    mock_client.get_profile.return_value = mock_profile
+    mock_client.get_timeline.return_value = Mock()
+    mock_client.get_author_feed.return_value = Mock()
+    mock_client.get_posts.return_value = Mock()
+    
+    # Mock session methods
+    mock_session = Mock()
+    mock_session.client.return_value = mock_client
+    mock_session.profile.return_value = mock_profile
+    mock_session.persist.return_value = None
+    
+    return mock_session, mock_client, mock_profile
+
+class MasterSessionManager:
+    """Manages master session backup for all test classes"""
+    
+    _backup_path = os.path.expanduser('~/.ssky_test_master_session_backup')
+    
+    @classmethod
+    def get_backup_path(cls):
+        """Get the master session backup file path"""
+        return cls._backup_path
+    
+    @classmethod
+    def exists(cls):
+        """Check if master session backup exists"""
+        return os.path.exists(cls._backup_path)
+    
+    @classmethod
+    def create_from_current_session(cls):
+        """Create master session backup from current session file"""
+        session_path = os.path.expanduser('~/.ssky')
+        if os.path.exists(session_path):
+            return create_master_session_backup(cls._backup_path)
+        return False
+    
+    @classmethod
+    def ensure_exists(cls):
+        """Ensure master session backup exists, create if needed"""
+        if not cls.exists():
+            return cls.create_from_current_session()
+        return True
+    
+    @classmethod
+    def ensure_session_available(cls):
+        """Ensure session file is available - restore from backup if needed"""
+        session_path = os.path.expanduser('~/.ssky')
+        
+        # If session file doesn't exist but backup exists, restore it
+        if not os.path.exists(session_path) and cls.exists():
+            return cls.restore_to_session()
+        
+        # If session file exists, ensure backup exists
+        if os.path.exists(session_path):
+            if not cls.exists():
+                return cls.create_from_current_session()
+            return True
+        
+        return False
+    
+    @classmethod
+    def restore_to_session(cls):
+        """Restore master session backup to current session file"""
+        if cls.exists():
+            session_path = os.path.expanduser('~/.ssky')
+            shutil.copy2(cls._backup_path, session_path)
+            return True
+        return False
+    
+    @classmethod
+    def cleanup(cls):
+        """Remove master session backup file"""
+        if cls.exists():
+            os.remove(cls._backup_path)
+            return True
+        return False
+
+class BaseSequentialTest:
+    """Base class for sequential tests to minimize Bluesky API calls
+    
+    Provides common setup methods for session backup management.
+    All test classes should inherit from this to avoid code duplication.
+    """
+    
+    @property
+    def master_session_backup(self):
+        """Get master session backup path"""
+        return MasterSessionManager.get_backup_path()
+    
+    @classmethod
+    def setup_class(cls):
+        """Class setup - ensure session file and backup are available"""
+        # Load environment variables first for all tests in this class
+        load_dotenv('tests/.env')
+        MasterSessionManager.ensure_session_available()
+    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,103 @@
+import pytest
+import os
+from tests.common import MasterSessionManager, setup, setup_with_session_copy
+from ssky.ssky_session import SskySession
+
+def pytest_sessionstart(session):
+    """Called after the Session object has been created and configured.
+    
+    This is called before test collection starts.
+    """
+    # Clean up any existing master session backup before tests start
+    MasterSessionManager.cleanup()
+    
+    # Create master session backup if existing session file is available
+    # Do NOT perform login here to preserve test_00_login.py as the only API caller
+    session_path = os.path.expanduser('~/.ssky')
+    if os.path.exists(session_path):
+        # Use existing session file to create backup
+        backup_created = MasterSessionManager.create_from_current_session()
+        if backup_created:
+            print(f"\nCreated master session backup from existing session file")
+    else:
+        print(f"\nNo existing session file found at {session_path}")
+        print("Non-login tests will be skipped until test_00_login.py creates a session")
+
+def pytest_sessionfinish(session, exitstatus):
+    """Called after whole test run finished, right before returning the exit status to the system.
+    
+    This is the perfect place to clean up any test artifacts.
+    """
+    # Clean up master session backup file after all tests complete
+    MasterSessionManager.cleanup()
+
+@pytest.fixture(autouse=False)
+def ssky_setup():
+    """Basic setup fixture for tests that need environment setup"""
+    setup()
+    yield
+    SskySession.clear()
+
+@pytest.fixture(autouse=False)
+def ssky_setup_no_session():
+    """Setup fixture for tests that need clean environment without session file"""
+    setup(no_session_file=True)
+    yield
+    SskySession.clear()
+
+@pytest.fixture(autouse=False)
+def ssky_setup_no_credentials():
+    """Setup fixture for tests that need environment without credentials"""
+    setup(envs_to_delete=['SSKY_USER'], no_session_file=True)
+    yield
+    SskySession.clear()
+
+@pytest.fixture(autouse=False)
+def ssky_setup_with_session_copy():
+    """Setup fixture for tests that use copied session file"""
+    def _setup_with_copy(envs_to_delete=[]):
+        if not MasterSessionManager.exists():
+            pytest.skip("Master session backup not available")
+        
+        SskySession.clear()
+        setup_with_session_copy(
+            master_session_path=MasterSessionManager.get_backup_path(),
+            envs_to_delete=envs_to_delete
+        )
+        return True
+    
+    yield _setup_with_copy
+    SskySession.clear()
+
+@pytest.fixture(autouse=False)
+def ssky_clean_environment():
+    """Fixture for tests that need completely clean environment"""
+    SskySession.clear()
+    yield
+    SskySession.clear()
+
+# Login test specific fixtures
+@pytest.fixture(autouse=False)
+def ssky_login_fresh_environment():
+    """Fixture for login tests that need fresh environment for session creation"""
+    SskySession.clear()
+    setup(no_session_file=True)
+    yield
+    SskySession.clear()
+
+@pytest.fixture(autouse=False)
+def ssky_login_session_only():
+    """Fixture for login tests that use session file without credentials"""
+    def _setup_session_only():
+        if not MasterSessionManager.exists():
+            pytest.skip("Master session backup not available")
+        
+        SskySession.clear()
+        setup_with_session_copy(
+            master_session_path=MasterSessionManager.get_backup_path(),
+            envs_to_delete=[]  # Keep credentials for session file validation
+        )
+        return True
+    
+    yield _setup_session_only
+    SskySession.clear() 

--- a/tests/test_00_ssky_session.py
+++ b/tests/test_00_ssky_session.py
@@ -1,0 +1,196 @@
+import os
+import json
+import pytest
+from unittest.mock import patch, Mock
+
+from ssky.ssky_session import SskySession
+from tests.common import (
+    setup, BaseSequentialTest,
+    MasterSessionManager, has_credentials
+)
+
+class TestSskySessionSequential(BaseSequentialTest):
+    """Sequential SskySession tests - the ONLY tests that use real atproto
+    
+    Strategy: Test SskySession functionality with real Bluesky API calls
+    and create session backup for other tests to use.
+    """
+    
+    def test_01_session_login_and_persistence(self):
+        """Test SskySession login with real credentials and session persistence
+        
+        This is the ONLY test that makes real API calls to Bluesky.
+        """
+        session_path = os.path.expanduser('~/.ssky')
+        
+        # Check if session file already exists
+        if os.path.exists(session_path):
+            # Issue warning and skip actual login
+            import warnings
+            warnings.warn(
+                f"Session file {session_path} already exists. "
+                "Skipping real Bluesky authentication and using existing session file. "
+                "Delete the file if you want to perform fresh authentication.",
+                UserWarning
+            )
+            
+            # Verify existing session file has content
+            with open(session_path, 'r') as f:
+                session_content = f.read()
+            assert session_content, "Existing session file should not be empty"
+            
+            # Test session loading from existing file
+            SskySession.clear()
+            session = SskySession()
+            assert SskySession.status() == SskySession.Status.LOGGED_IN, "Should be logged in from existing session"
+            
+            # Create backup for other tests using existing session
+            backup_created = MasterSessionManager.create_from_current_session()
+            assert backup_created, "Master session backup should be created from existing session"
+            
+            SskySession.clear()
+            return  # Skip the actual login process
+        
+        # Clear any existing session
+        SskySession.clear()
+        
+        # Setup with fresh credentials
+        setup(no_session_file=True)
+        
+        # Check for credentials
+        if not has_credentials():
+            pytest.skip("SSKY_USER environment variable not set")
+        
+        # Get credentials from environment
+        credentials = os.environ.get('SSKY_USER')
+        handle, password = credentials.split(':', 1)
+        
+        # Test 1: Create session with credentials
+        session = SskySession(handle=handle, password=password)
+        assert SskySession.status() == SskySession.Status.LOGGED_IN, "Should be logged in"
+        
+        # Test 2: Verify client and profile are available
+        client = session.client()
+        assert client is not None, "Client should be available"
+        
+        profile = session.profile()
+        assert profile is not None, "Profile should be available"
+        assert hasattr(profile, 'did'), "Profile should have DID"
+        assert profile.did is not None, "Profile DID should not be None"
+        
+        # Test 3: Session persistence
+        session.persist()
+        assert os.path.exists(session_path), "Session file should be created"
+        
+        # Test 4: Verify session file content
+        with open(session_path, 'r') as f:
+            session_data = json.load(f)
+        assert 'session_string' in session_data, "Session file should contain session_string"
+        assert session_data['session_string'], "Session string should not be empty"
+        
+        # Test 5: Clear and reload session from file
+        SskySession.clear()
+        assert SskySession.status() == SskySession.Status.NOT_LOGGED_IN, "Should be logged out after clear"
+        
+        # Create new session (should load from file)
+        session2 = SskySession()
+        assert SskySession.status() == SskySession.Status.LOGGED_IN, "Should be logged in from file"
+        
+        # Verify client and profile are still available
+        client2 = session2.client()
+        assert client2 is not None, "Client should be available from persisted session"
+        
+        profile2 = session2.profile()
+        assert profile2 is not None, "Profile should be available from persisted session"
+        assert profile2.did == profile.did, "Profile DID should match original"
+        
+        # Create backup for other tests
+        backup_created = MasterSessionManager.create_from_current_session()
+        assert backup_created, "Master session backup should be created"
+        
+        # Cleanup
+        SskySession.clear()
+    
+    def test_02_session_status_management(self):
+        """Test SskySession status management without API calls"""
+        
+        # Test 1: Initial state
+        SskySession.clear()
+        assert SskySession.status() == SskySession.Status.NOT_LOGGED_IN, "Initial status should be NOT_LOGGED_IN"
+        
+        # Test 2: Login failed state
+        SskySession.session = SskySession.login_failed
+        assert SskySession.status() == SskySession.Status.LOGIN_FAILED, "Status should be LOGIN_FAILED"
+        
+        # Test 3: Clear function
+        SskySession.clear()
+        assert SskySession.status() == SskySession.Status.NOT_LOGGED_IN, "Status should be NOT_LOGGED_IN after clear"
+        assert SskySession.session is None, "Session should be None after clear"
+        
+        # Cleanup
+        SskySession.clear()
+    
+    def test_03_session_error_handling(self):
+        """Test SskySession error handling with invalid credentials"""
+        
+        SskySession.clear()
+        setup(no_session_file=True)
+        
+        # Test with invalid credentials (should cause login failure)
+        with patch('ssky.ssky_session.atproto.Client') as mock_client_class:
+            import atproto_client
+            mock_client = Mock()
+            mock_client.login.side_effect = atproto_client.exceptions.AtProtocolError("Invalid credentials")
+            mock_client_class.return_value = mock_client
+            
+            # This should set session to login_failed (not raise exception)
+            session = SskySession(handle="invalid", password="invalid")
+            assert SskySession.status() == SskySession.Status.LOGIN_FAILED, "Status should be LOGIN_FAILED for invalid credentials"
+            
+            # Test client() method with failed session
+            client = session.client()
+            assert client is None, "Client should be None for failed session"
+            
+            # Test profile() method with failed session
+            profile = session.profile()
+            assert profile is None, "Profile should be None for failed session"
+        
+        # Cleanup
+        SskySession.clear()
+    
+    def test_04_session_without_credentials(self):
+        """Test SskySession behavior when no credentials are available"""
+        
+        SskySession.clear()
+        
+        # Manually clean environment - don't use setup() which loads .env
+        import os
+        if 'SSKY_USER' in os.environ:
+            del os.environ['SSKY_USER']
+        
+        # Test session creation without credentials and without session file
+        # With current implementation, this raises LoginRequiredError
+        import atproto_client
+        
+        with pytest.raises(atproto_client.exceptions.LoginRequiredError):
+            session = SskySession()
+        
+        # After the failed initialization, session should be in login_failed state
+        assert SskySession.status() == SskySession.Status.LOGIN_FAILED, "Status should be LOGIN_FAILED without credentials"
+        
+        # Create a session object to test the methods (even though init failed)
+        # The session object itself can be created, but the class state is login_failed
+        session = SskySession.__new__(SskySession)  # Create without calling __init__
+        
+        # Test that client and profile return None for failed session
+        client = session.client()
+        assert client is None, "Client should be None for failed session"
+        
+        profile = session.profile()
+        assert profile is None, "Profile should be None for failed session"
+        
+        # persist() should do nothing for failed session
+        session.persist()  # Should not raise
+        
+        # Cleanup
+        SskySession.clear() 

--- a/tests/test_follow_unfollow.py
+++ b/tests/test_follow_unfollow.py
@@ -1,53 +1,222 @@
 import os
+import tempfile
+import pytest
+from unittest.mock import patch, Mock
+
 from ssky.profile_list import ProfileList
 from ssky.follow import follow
 from ssky.unfollow import unfollow
-from tests.common import setup, teardown
+from ssky.ssky_session import SskySession
+from ssky.util import ErrorResult
+from tests.common import create_mock_ssky_session, has_credentials
 
-def test_follow_by_handle():
-    setup()
-    result = follow(os.environ.get('SSKY_TEST_HANDLE'))
-    teardown()
-    assert type(result) is ProfileList
+@pytest.fixture
+def mock_follow_environment():
+    """Setup test environment for follow/unfollow tests"""
+    if not has_credentials():
+        pytest.skip("No credentials available")
+    
+    # Create mock session for all follow/unfollow tests
+    mock_session, mock_client, mock_profile = create_mock_ssky_session()
+    
+    # Set up proper mock responses for follow/unfollow functionality
+    # Mock follow response
+    mock_follow_response = Mock()
+    mock_follow_response.uri = "at://test.user/app.bsky.graph.follow/test123"
+    mock_client.follow.return_value = mock_follow_response
+    
+    # Mock unfollow response
+    mock_client.unfollow.return_value = True
+    
+    # Mock profile response for follow functionality
+    mock_profile_response = Mock()
+    mock_profile_response.did = "did:plc:test123"
+    mock_client.app.bsky.actor.get_profile.return_value = mock_profile_response
+    
+    # Mock follows response for unfollow functionality
+    mock_follow = Mock()
+    mock_follow.did = "did:plc:test123"
+    mock_follow.handle = "test.bsky.social"
+    mock_follow.viewer = Mock()
+    mock_follow.viewer.following = "at://test.user/app.bsky.graph.follow/test123"
+    
+    mock_follows_response = Mock()
+    mock_follows_response.follows = [mock_follow]
+    mock_client.get_follows.return_value = mock_follows_response
+    
+    return mock_session, mock_client, mock_profile
 
-def test_unfollow_by_handle():
-    setup(interval=5)
-    result = unfollow(os.environ.get('SSKY_TEST_HANDLE'))
-    teardown()
-    assert type(result) is ProfileList
-
-def test_unfollow_by_not_following_handle():
-    setup(interval=5)
-    result = unfollow(os.environ.get('SSKY_TEST_HANDLE'))
-    teardown()
-    assert result is None
-
-def test_follow_by_did():
-    setup()
-    result = follow(os.environ.get('SSKY_TEST_DID'))
-    teardown()
-    assert type(result) is ProfileList
-
-def test_unfollow_by_did():
-    setup(interval=5)
-    result = unfollow(os.environ.get('SSKY_TEST_DID'))
-    teardown()
-    assert type(result) is ProfileList
-
-def test_unfollow_by_not_following_did():
-    setup(interval=5)
-    result = unfollow(os.environ.get('SSKY_TEST_DID'))
-    teardown()
-    assert result is None
-
-def test_follow_by_invalid_did():
-    setup()
-    result = follow(os.environ.get('SSKY_TEST_INVALID_DID'))
-    teardown()
-    assert result is None
-
-def test_unfollow_by_invalid_did():
-    setup()
-    result = unfollow(os.environ.get('SSKY_TEST_INVALID_DID'))
-    teardown()
-    assert result is None
+class TestFollowUnfollowSequential:
+    """Sequential follow/unfollow tests using mocked SskySession
+    
+    Strategy: 1 real follow/unfollow cycle + mocked tests for other scenarios
+    This reduces API calls and avoids rate limits.
+    """
+    
+    def test_01_real_follow_unfollow_by_handle(self):
+        """Real API test - follow and unfollow by handle (only real API test in this file)"""
+        # Skip if no credentials available
+        if not has_credentials():
+            pytest.skip("SSKY_USER environment variable not set")
+        
+        # This test uses real API calls - no mocking
+        try:
+            handle = os.environ.get('SSKY_TEST_HANDLE', 'test.bsky.social')
+            
+            # Follow
+            follow_result = follow(handle)
+            assert isinstance(follow_result, ProfileList), "Follow should return ProfileList"
+            
+            # Wait a bit before unfollowing
+            import time
+            time.sleep(5)
+            
+            # Unfollow
+            unfollow_result = unfollow(handle)
+            assert isinstance(unfollow_result, ProfileList), "Unfollow should return ProfileList"
+            
+        finally:
+            SskySession.clear()
+    
+    def test_02_follow_by_did_with_mock(self, mock_follow_environment):
+        """Test follow by DID using mocked session"""
+        mock_session, mock_client, mock_profile = mock_follow_environment
+        
+        with patch('ssky.follow.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            did = os.environ.get('SSKY_TEST_DID', 'did:plc:test123')
+            result = follow(did)
+            
+            assert isinstance(result, ProfileList), "Follow should return ProfileList"
+    
+    def test_03_unfollow_by_did_with_mock(self, mock_follow_environment):
+        """Test unfollow by DID using mocked session"""
+        mock_session, mock_client, mock_profile = mock_follow_environment
+        
+        # Update mock to match the test DID
+        mock_follow = Mock()
+        mock_follow.did = os.environ.get('SSKY_TEST_DID', 'did:plc:test123')
+        mock_follow.handle = "test.bsky.social"
+        mock_follow.viewer = Mock()
+        mock_follow.viewer.following = "at://test.user/app.bsky.graph.follow/test123"
+        
+        mock_follows_response = Mock()
+        mock_follows_response.follows = [mock_follow]
+        mock_client.get_follows.return_value = mock_follows_response
+        
+        with patch('ssky.unfollow.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            did = os.environ.get('SSKY_TEST_DID', 'did:plc:test123')
+            result = unfollow(did)
+            
+            assert isinstance(result, ProfileList), "Unfollow should return ProfileList"
+    
+    def test_04_unfollow_not_following_user(self, mock_follow_environment):
+        """Test unfollow user that is not being followed"""
+        mock_session, mock_client, mock_profile = mock_follow_environment
+        
+        # Mock follows response with empty list (not following anyone)
+        mock_follows_response = Mock()
+        mock_follows_response.follows = []
+        mock_client.get_follows.return_value = mock_follows_response
+        
+        with patch('ssky.unfollow.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            handle = os.environ.get('SSKY_TEST_HANDLE', 'test.bsky.social')
+            result = unfollow(handle)
+            
+            assert isinstance(result, ErrorResult), "Unfollow should return ErrorResult when not following"
+    
+    def test_05_follow_invalid_user(self, mock_follow_environment):
+        """Test follow with invalid user"""
+        mock_session, mock_client, mock_profile = mock_follow_environment
+        
+        # Mock get_profile to raise exception for invalid user
+        import atproto_client
+        mock_client.get_profile.side_effect = atproto_client.exceptions.AtProtocolError("User not found")
+        
+        with patch('ssky.follow.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            invalid_did = os.environ.get('SSKY_TEST_INVALID_DID', 'did:plc:invalid123')
+            result = follow(invalid_did)
+            
+            assert isinstance(result, ErrorResult), "Follow should return ErrorResult for invalid user"
+    
+    def test_06_unfollow_invalid_user(self, mock_follow_environment):
+        """Test unfollow with invalid user"""
+        mock_session, mock_client, mock_profile = mock_follow_environment
+        
+        # Mock get_follows to raise exception for invalid user
+        import atproto_client
+        mock_client.get_follows.side_effect = atproto_client.exceptions.AtProtocolError("User not found")
+        
+        with patch('ssky.unfollow.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            invalid_did = os.environ.get('SSKY_TEST_INVALID_DID', 'did:plc:invalid123')
+            result = unfollow(invalid_did)
+            
+            assert isinstance(result, ErrorResult), "Unfollow should return ErrorResult for invalid user"
+    
+    def test_07_follow_unfollow_error_scenarios(self):
+        """Test error handling scenarios"""
+        # Test 1: No session available for follow
+        with patch('ssky.follow.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = None
+            
+            result = follow("test.bsky.social")
+            assert isinstance(result, ErrorResult), "Follow should return ErrorResult when no session available"
+            assert result.http_code == 401, "Should return 401 error code"
+        
+        # Test 2: No session available for unfollow
+        with patch('ssky.unfollow.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = None
+            
+            result = unfollow("test.bsky.social")
+            assert isinstance(result, ErrorResult), "Unfollow should return ErrorResult when no session available"
+            assert result.http_code == 401, "Should return 401 error code"
+        
+        # Test 3: Empty identifier for follow
+        result = follow("")
+        assert isinstance(result, ErrorResult), "Follow should return ErrorResult with empty identifier"
+        
+        # Test 4: Empty identifier for unfollow
+        result = unfollow("")
+        assert isinstance(result, ErrorResult), "Unfollow should return ErrorResult with empty identifier"
+    
+    def test_08_follow_unfollow_with_json_format(self, mock_follow_environment):
+        """Test follow/unfollow with JSON format output"""
+        mock_session, mock_client, mock_profile = mock_follow_environment
+        
+        # Test follow with JSON format
+        with patch('ssky.follow.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            handle = os.environ.get('SSKY_TEST_HANDLE', 'test.bsky.social')
+            result = follow(handle, format='json')
+            
+            assert isinstance(result, ProfileList), "Follow should return ProfileList with JSON format"
+        
+        # Test unfollow with JSON format
+        # Update mock to match the test handle
+        handle = os.environ.get('SSKY_TEST_HANDLE', 'test.bsky.social')
+        mock_follow = Mock()
+        mock_follow.did = "did:plc:test123"
+        mock_follow.handle = handle  # Use the actual test handle
+        mock_follow.viewer = Mock()
+        mock_follow.viewer.following = "at://test.user/app.bsky.graph.follow/test123"
+        
+        mock_follows_response = Mock()
+        mock_follows_response.follows = [mock_follow]
+        mock_client.get_follows.return_value = mock_follows_response
+        
+        with patch('ssky.unfollow.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            result = unfollow(handle, format='json')
+            
+            assert isinstance(result, ProfileList), "Unfollow should return ProfileList with JSON format"

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -1,64 +1,176 @@
 import os
+import pytest
+from unittest.mock import Mock, patch
+
 from ssky.get import get
 from ssky.post_data_list import PostDataList
-from tests.common import setup, teardown
+from ssky.ssky_session import SskySession
+from ssky.util import ErrorResult
+from tests.common import create_mock_ssky_session, has_credentials
 
-def test_get_timeline():
-    setup()
-    result = get(target=None)
-    teardown()
-    assert type(result) is PostDataList
+@pytest.fixture
+def mock_get_environment():
+    """Setup test environment for get tests"""
+    if not has_credentials():
+        pytest.skip("No credentials available")
+    
+    # Create mock session for all get tests
+    mock_session, mock_client, mock_profile = create_mock_ssky_session()
+    
+    # Set up proper mock responses for get functionality
+    # Mock post for posts response
+    mock_post = Mock()
+    mock_post.uri = "at://test.user/app.bsky.feed.post/test123"
+    mock_post.cid = "testcid123"
+    mock_post.author = Mock()
+    mock_post.author.did = "did:plc:test123"
+    mock_post.author.handle = "test.bsky.social"
+    mock_post.record = Mock()
+    mock_post.record.text = "Test post content"
+    
+    # Mock feed post for feed responses
+    mock_feed_post = Mock()
+    mock_feed_post.post = mock_post
+    
+    # Set up timeline response
+    mock_timeline_response = Mock()
+    mock_timeline_response.feed = [mock_feed_post]
+    mock_client.get_timeline.return_value = mock_timeline_response
+    
+    # Set up author feed response
+    mock_author_feed_response = Mock()
+    mock_author_feed_response.feed = [mock_feed_post]
+    mock_client.get_author_feed.return_value = mock_author_feed_response
+    
+    # Set up posts response
+    mock_posts_response = Mock()
+    mock_posts_response.posts = [mock_post]
+    mock_client.get_posts.return_value = mock_posts_response
+    
+    return mock_session, mock_client, mock_profile
 
-def test_get_myself():
-    setup()
-    result = get(target='myself')
-    teardown()
-    assert type(result) is PostDataList
+class TestGetSequential:
+    """Sequential tests for get functionality using mocked SskySession"""
+    
+    def test_01_real_get_timeline(self):
+        """Real API test - get timeline (only real API test in this file)"""
+        # Skip if no credentials available
+        if not has_credentials():
+            pytest.skip("SSKY_USER environment variable not set")
+        
+        # This test uses real API calls - no mocking
+        try:
+            result = get(target=None)
+            assert isinstance(result, PostDataList), "Get timeline should return PostDataList"
+        finally:
+            SskySession.clear()
+    
+    def test_02_get_myself(self, mock_get_environment):
+        """Test get my own posts using mocked session"""
+        mock_session, mock_client, mock_profile = mock_get_environment
+        
+        with patch('ssky.get.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            result = get(target='myself')
+            assert isinstance(result, PostDataList), "Get myself should return PostDataList"
+    
+    def test_03_get_with_actor_handle(self, mock_get_environment):
+        """Test get posts by actor handle"""
+        mock_session, mock_client, mock_profile = mock_get_environment
+        
+        with patch('ssky.get.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            handle = os.environ.get('SSKY_TEST_HANDLE', 'test.bsky.social')
+            result = get(target=handle)
+            
+            assert isinstance(result, PostDataList), "Get by handle should return PostDataList"
+    
+    def test_04_get_with_actor_did(self, mock_get_environment):
+        """Test get posts by actor DID"""
+        mock_session, mock_client, mock_profile = mock_get_environment
+        
+        with patch('ssky.get.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            did = os.environ.get('SSKY_TEST_DID', 'did:plc:test123')
+            result = get(target=did)
+            
+            assert isinstance(result, PostDataList), "Get by DID should return PostDataList"
+    
+    def test_05_get_with_at_uri(self, mock_get_environment):
+        """Test get specific post by AT URI"""
+        mock_session, mock_client, mock_profile = mock_get_environment
+        
+        with patch('ssky.get.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            uri = os.environ.get('SSKY_TEST_URI', 'at://test.user/app.bsky.feed.post/test123')
+            result = get(target=uri)
+            
+            assert isinstance(result, PostDataList), "Get by URI should return PostDataList"
+    
+    def test_06_get_with_at_uri_cid(self, mock_get_environment):
+        """Test get specific post by AT URI with CID"""
+        mock_session, mock_client, mock_profile = mock_get_environment
+        
+        with patch('ssky.get.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            uri_cid = os.environ.get('SSKY_TEST_URI_CID', 'at://test.user/app.bsky.feed.post/test123|testcid123')
+            result = get(target=uri_cid)
+            
+            assert isinstance(result, PostDataList), "Get by URI+CID should return PostDataList"
+    
+    def test_07_get_invalid_targets(self, mock_get_environment):
+        """Test get with invalid targets"""
+        mock_session, mock_client, mock_profile = mock_get_environment
+        
+        # Mock exception for invalid targets
+        import atproto_client
+        mock_client.get_author_feed.side_effect = atproto_client.exceptions.AtProtocolError("Not found")
+        mock_client.get_posts.side_effect = atproto_client.exceptions.AtProtocolError("Not found")
+        
+        with patch('ssky.get.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            # Test invalid handle
+            invalid_handle = os.environ.get('SSKY_TEST_INVALID_HANDLE', 'invalid.handle.test')
+            result = get(target=invalid_handle)
+            assert isinstance(result, ErrorResult), "Get with invalid handle should return ErrorResult"
+            
+            # Test invalid DID
+            invalid_did = os.environ.get('SSKY_TEST_INVALID_DID', 'did:plc:invalid123')
+            result = get(target=invalid_did)
+            assert isinstance(result, ErrorResult), "Get with invalid DID should return ErrorResult"
+            
+            # Test invalid URI
+            invalid_uri = os.environ.get('SSKY_TEST_INVALID_URI', 'at://invalid/uri')
+            result = get(target=invalid_uri)
+            assert isinstance(result, ErrorResult), "Get with invalid URI should return ErrorResult"
+            
+            # Test invalid URI+CID
+            invalid_uri_cid = os.environ.get('SSKY_TEST_INVALID_URI_CID', 'at://invalid/uri|invalidcid')
+            result = get(target=invalid_uri_cid)
+            assert isinstance(result, ErrorResult), "Get with invalid URI+CID should return ErrorResult"
+    
+    def test_08_get_error_scenarios(self):
+        """Test error handling scenarios"""
+        # Test: No session available
+        with patch('ssky.get.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = None
+            
+            result = get(target=None)
+            assert isinstance(result, ErrorResult), "Get should return ErrorResult when no session available"
+            assert result.http_code == 401, "Get should return 401 error code"
+    
+    def test_09_get_with_json_format(self, mock_get_environment):
+        """Test get with JSON format output"""
+        mock_session, mock_client, mock_profile = mock_get_environment
+        
+        with patch('ssky.get.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
 
-def test_get_with_actor_handle():
-    setup()
-    result = get(target=os.environ.get('SSKY_TEST_HANDLE'))
-    teardown()
-    assert type(result) is PostDataList
-
-def test_get_with_actor_did():
-    setup()
-    result = get(target=os.environ.get('SSKY_TEST_DID'))
-    teardown()
-    assert type(result) is PostDataList
-
-def test_get_with_at_uri():
-    setup()
-    result = get(target=os.environ.get('SSKY_TEST_URI'))
-    teardown()
-    assert type(result) is PostDataList
-
-def test_get_with_at_uri_cid():
-    setup()
-    result = get(target=os.environ.get('SSKY_TEST_URI_CID'))
-    teardown()
-    assert type(result) is PostDataList
-
-def test_get_with_invalid_actor_handle():
-    setup()
-    result = get(target=os.environ.get('SSKY_TEST_INVALID_HANDLE'))
-    teardown()
-    assert result is None
-
-def test_get_with_invalid_actor_did():
-    setup()
-    result = get(target=os.environ.get('SSKY_TEST_INVALID_DID'))
-    teardown()
-    assert result is None
-
-def test_get_with_invalid_uri():
-    setup()
-    result = get(target=os.environ.get('SSKY_TEST_INVALID_URI'))
-    teardown()
-    assert result is None
-
-def test_get_with_invalid_uri_cid():
-    setup()
-    result = get(target=os.environ.get('SSKY_TEST_INVALID_URI_CID'))
-    teardown()
-    assert result is None
+            result = get(target=None, format='json')
+            assert isinstance(result, PostDataList), "Get with JSON format should return PostDataList"

--- a/tests/test_login.py
+++ b/tests/test_login.py
@@ -1,193 +1,273 @@
 import os
-import tempfile
 import pytest
 from unittest.mock import patch, Mock
 
 from ssky.login import login
 from ssky.profile_list import ProfileList
-from ssky.ssky_session import SskySession
+from ssky.util import ErrorResult
 from tests.common import (
-    setup, teardown, create_master_session_backup, 
-    setup_with_session_copy, cleanup_session_file, create_mock_atproto_client
+    create_mock_ssky_session, BaseSequentialTest,
+    MasterSessionManager, has_credentials
 )
 
-class TestLoginSequential:
-    """Sequential login tests to minimize Bluesky API calls
+@pytest.fixture
+def mock_ssky_session():
+    """Fixture that provides a mock SskySession for testing"""
+    return create_mock_ssky_session()
+
+@pytest.fixture
+def login_environment():
+    """Fixture that sets up login test environment"""
+    # Load environment variables
+    from dotenv import load_dotenv
+    load_dotenv('tests/.env')
     
-    Strategy: 1 real authentication + session file copying for other tests
-    This reduces API calls from 4 to 1 per test run, avoiding rate limits.
+    # Clear any existing session state
+    from ssky.ssky_session import SskySession
+    SskySession.clear()
+    
+    yield
+    
+    # Cleanup
+    SskySession.clear()
+
+@pytest.fixture
+def credentials_available():
+    """Fixture that checks if credentials are available"""
+    if not has_credentials():
+        pytest.skip("SSKY_USER environment variable not set")
+    return True
+
+class TestLoginSequential(BaseSequentialTest):
+    """Login function tests using mocked SskySession
+    
+    These tests focus on the login() function logic without making real API calls.
+    SskySession is mocked to avoid actual authentication.
     """
     
-    master_session_backup = None
-    
-    @classmethod
-    def setup_class(cls):
-        """Class setup - prepare temporary file for session backup"""
-        cls.temp_dir = tempfile.mkdtemp()
-        cls.master_session_backup = os.path.join(cls.temp_dir, 'master_session.json')
-    
-    @classmethod
-    def teardown_class(cls):
-        """Class teardown - cleanup temporary files"""
-        if cls.master_session_backup and os.path.exists(cls.master_session_backup):
-            os.remove(cls.master_session_backup)
-        if hasattr(cls, 'temp_dir') and os.path.exists(cls.temp_dir):
-            os.rmdir(cls.temp_dir)
-    
-    def test_01_create_master_session(self):
-        """Master session creation - ONLY test that performs real Bluesky authentication
+    def test_01_login_with_credentials_parameter(self, login_environment, mock_ssky_session):
+        """Test login with explicit credentials parameter"""
         
-        This test makes the single API call to Bluesky and creates a session backup
-        for other tests to use.
-        """
-        # Clear any existing session
-        SskySession.clear()
-        cleanup_session_file()
-        
-        # Setup with fresh credentials
-        setup(no_session_file=True)
-        
-        # Get credentials from environment
-        credentials = os.environ.get('SSKY_USER')
-        if not credentials:
-            pytest.skip("SSKY_USER environment variable not set")
-        
-        # Perform real authentication (the only API call in this test suite)
-        result = login(credentials=credentials)
-        
-        # Verify successful login
-        assert isinstance(result, ProfileList), "Login should return ProfileList"
-        
-        # Verify session file was created
-        session_path = os.path.expanduser('~/.ssky')
-        assert os.path.exists(session_path), "Session file should be created"
-        
-        # Read and verify session content
-        with open(session_path, 'r') as f:
-            session_content = f.read()
-        assert session_content, "Session file should not be empty"
-        
-        # Create backup for other tests
-        backup_created = create_master_session_backup(self.master_session_backup)
-        assert backup_created, "Master session backup should be created"
-        
-        # Cleanup
-        teardown()
-        SskySession.clear()
-    
-    def test_02_login_using_session_file(self):
-        """Test login using existing session file (no API calls)
-        
-        Uses the session file created by test_01, no network calls.
-        """
-        # Skip if master session not available
-        if not os.path.exists(self.master_session_backup):
+        # Skip if master session not available for environment setup
+        if not MasterSessionManager.exists():
             pytest.skip("Master session backup not available")
         
-        # Clear session and setup with copied session file
-        SskySession.clear()
-        setup_with_session_copy(
-            master_session_path=self.master_session_backup,
-            envs_to_delete=['SSKY_USER']  # Remove credentials to force session file usage
-        )
-        
-        # Login using session file (no API call)
-        result = login()
-        
-        # Verify successful login
-        assert isinstance(result, ProfileList), "Login should return ProfileList"
-        
-        # Verify session file exists and has content
-        session_path = os.path.expanduser('~/.ssky')
-        assert os.path.exists(session_path), "Session file should exist"
-        
-        with open(session_path, 'r') as f:
-            session_content = f.read()
-        assert session_content, "Session file should not be empty"
-        
-        # Cleanup
-        teardown()
-        SskySession.clear()
-    
-    def test_03_login_credential_parsing(self):
-        """Test credential parsing logic with mocked API calls
-        
-        Tests the credential parsing without making real API calls.
-        """
-        # Skip if master session not available (needed for environment setup)
-        if not os.path.exists(self.master_session_backup):
-            pytest.skip("Master session backup not available")
-        
-        SskySession.clear()
-        cleanup_session_file()
-        
-        # Setup environment
-        setup(no_session_file=True)
-        
-        # Create mock client
-        mock_client, mock_profile = create_mock_atproto_client()
+        # Unpack mock objects
+        mock_session, mock_client, mock_profile = mock_ssky_session
         
         # Test credential parsing with mock
-        with patch('atproto.Client') as mock_client_class:
-            mock_client_class.return_value = mock_client
+        with patch('ssky.login.SskySession') as mock_session_class:
+            mock_session_class.return_value = mock_session
             
             # Test with explicit credentials
             credentials = "test.handle:testpassword"
             result = login(credentials=credentials)
             
-            # Verify mock was called correctly
-            mock_client.login.assert_called_once()
-            call_args = mock_client.login.call_args
+            # Verify session was created with parsed credentials
+            mock_session_class.assert_called_once()
+            call_args = mock_session_class.call_args
             
-            # Verify credentials were parsed correctly
-            assert 'login' in call_args.kwargs or len(call_args.args) >= 1
-            assert 'password' in call_args.kwargs or len(call_args.args) >= 2
+            # Check if credentials were parsed correctly
+            assert 'handle' in call_args.kwargs, "Should pass handle parameter"
+            assert 'password' in call_args.kwargs, "Should pass password parameter"
+            assert call_args.kwargs['handle'] == "test.handle", "Handle should be parsed correctly"
+            assert call_args.kwargs['password'] == "testpassword", "Password should be parsed correctly"
+            
+            # Verify session methods were called
+            mock_session.persist.assert_called_once()
+            mock_session.profile.assert_called_once()
             
             # Verify result
             assert isinstance(result, ProfileList), "Should return ProfileList"
-        
-        # Cleanup
-        teardown()
-        SskySession.clear()
     
-    def test_04_login_error_scenarios(self):
-        """Test error handling without real API calls
+    def test_02_login_with_environment_credentials(self, login_environment, credentials_available, mock_ssky_session):
+        """Test login using SSKY_USER environment variable"""
         
-        Tests various error conditions that the login function can handle.
-        """
-        SskySession.clear()
-        cleanup_session_file()
+        # Skip if master session not available for environment setup
+        if not MasterSessionManager.exists():
+            pytest.skip("Master session backup not available")
         
-        # Test 1: No credentials available
-        setup(envs_to_delete=['SSKY_USER'], no_session_file=True)
-        result = login()
-        assert result is None, "Login should fail when no credentials available"
-        
-        # Test 2: Mock AtProtocolError during session creation
-        setup(no_session_file=True)
-        
-        # Mock SskySession to raise AtProtocolError (which login() catches)
-        import atproto_client
+        # Unpack mock objects
+        mock_session, mock_client, mock_profile = mock_ssky_session
         
         with patch('ssky.login.SskySession') as mock_session_class:
-            # Mock session that raises AtProtocolError
-            mock_session_class.side_effect = atproto_client.exceptions.AtProtocolError("Mock authentication failed")
+            mock_session_class.return_value = mock_session
             
-            # Set up environment variable for credentials
-            os.environ['SSKY_USER'] = 'test.handle:testpassword'
-            
-            # This should handle the exception gracefully and return None
+            # Test login without explicit credentials (should use environment)
             result = login()
-            assert result is None, "Login should return None on AtProtocolError"
+            
+            # Verify session was created
+            mock_session_class.assert_called_once()
+            
+            # Verify session methods were called
+            mock_session.persist.assert_called_once()
+            mock_session.profile.assert_called_once()
+            
+            # Verify result
+            assert isinstance(result, ProfileList), "Should return ProfileList"
+    
+    def test_03_login_credential_parsing_edge_cases(self, login_environment, mock_ssky_session):
+        """Test credential parsing with various edge cases"""
         
-        # Test 3: Test credential parsing with empty string
+        # Unpack mock objects
+        mock_session, mock_client, mock_profile = mock_ssky_session
+        
+        # Test 1: Empty credentials
         result = login(credentials="")
-        assert result is None, "Login should return None for empty credentials"
+        assert isinstance(result, ErrorResult), "Should return ErrorResult for empty credentials"
+        assert result.http_code == 400, "Should return 400 error code"
         
-        # Test 4: Test credential parsing with invalid format (no colon)
+        # Test 2: Invalid format (no colon)
         result = login(credentials="invalid_format")
-        assert result is None, "Login should return None for invalid credential format"
+        assert isinstance(result, ErrorResult), "Should return ErrorResult for invalid format"
+        assert result.http_code == 400, "Should return 400 error code"
         
-        # Cleanup
-        teardown()
+        # Test 3: Only whitespace
+        result = login(credentials="   ")
+        assert isinstance(result, ErrorResult), "Should return ErrorResult for whitespace-only credentials"
+        assert result.http_code == 400, "Should return 400 error code"
+        
+        # Test 4: Valid format with colon
+        with patch('ssky.login.SskySession') as mock_session_class:
+            mock_session_class.return_value = mock_session
+            
+            result = login(credentials="user:pass")
+            assert isinstance(result, ProfileList), "Should return ProfileList for valid credentials"
+            
+            # Verify correct parsing
+            call_args = mock_session_class.call_args
+            assert call_args.kwargs['handle'] == "user", "Handle should be parsed correctly"
+            assert call_args.kwargs['password'] == "pass", "Password should be parsed correctly"
+    
+    def test_04_login_session_error_handling(self, login_environment):
+        """Test error handling when SskySession raises exceptions"""
+        
+        # Test 1: LoginRequiredError from SskySession
+        with patch('ssky.login.SskySession') as mock_session_class:
+            import atproto_client
+            mock_session_class.side_effect = atproto_client.exceptions.LoginRequiredError("Mock login required")
+            
+            result = login(credentials="test:test")
+            assert isinstance(result, ErrorResult), "Should return ErrorResult on LoginRequiredError"
+            assert result.http_code == 401, "Should return 401 error code"
+        
+        # Test 2: AtProtocolError from SskySession
+        with patch('ssky.login.SskySession') as mock_session_class:
+            import atproto_client
+            mock_session_class.side_effect = atproto_client.exceptions.AtProtocolError("Mock auth failed")
+            
+            result = login(credentials="test:test")
+            assert isinstance(result, ErrorResult), "Should return ErrorResult on AtProtocolError"
+        
+        # Test 3: Generic Exception from SskySession
+        with patch('ssky.login.SskySession') as mock_session_class:
+            mock_session_class.side_effect = Exception("Mock unexpected error")
+            
+            result = login(credentials="test:test")
+            assert isinstance(result, ErrorResult), "Should return ErrorResult on generic Exception"
+            assert result.http_code == 500, "Should return 500 error code"
+    
+    def test_05_login_profile_availability_check(self, login_environment, mock_ssky_session):
+        """Test profile availability check after login"""
+        
+        # Unpack mock objects
+        mock_session, mock_client, mock_profile = mock_ssky_session
+        
+        # Test 1: Profile is None
+        mock_session.profile.return_value = None
+        
+        with patch('ssky.login.SskySession') as mock_session_class:
+            mock_session_class.return_value = mock_session
+            
+            result = login(credentials="test:test")
+            assert isinstance(result, ErrorResult), "Should return ErrorResult when profile is None"
+            assert result.http_code == 500, "Should return 500 error code"
+        
+        # Test 2: Profile has no DID
+        mock_session, mock_client, mock_profile = create_mock_ssky_session()
+        mock_profile.did = None
+        
+        with patch('ssky.login.SskySession') as mock_session_class:
+            mock_session_class.return_value = mock_session
+            
+            result = login(credentials="test:test")
+            assert isinstance(result, ErrorResult), "Should return ErrorResult when profile has no DID"
+            assert result.http_code == 500, "Should return 500 error code"
+        
+        # Test 3: Profile missing DID attribute
+        mock_session, mock_client, mock_profile = create_mock_ssky_session()
+        del mock_profile.did  # Remove the attribute entirely
+        
+        with patch('ssky.login.SskySession') as mock_session_class:
+            mock_session_class.return_value = mock_session
+            
+            result = login(credentials="test:test")
+            assert isinstance(result, ErrorResult), "Should return ErrorResult when profile missing DID attribute"
+            assert result.http_code == 500, "Should return 500 error code"
+    
+    def test_06_login_no_credentials_available(self, login_environment):
+        """Test login behavior when no credentials are available but session file exists"""
+        
+        # Temporarily remove SSKY_USER environment variable
+        original_user = os.environ.get('SSKY_USER')
+        if 'SSKY_USER' in os.environ:
+            del os.environ['SSKY_USER']
+        
+        # Clear session state but keep session file (normal behavior)
+        from ssky.ssky_session import SskySession
         SskySession.clear()
+        
+        try:
+            # Test login without explicit credentials
+            # Should succeed if valid session file exists (normal behavior)
+            result = login()
+            
+            # Check if session file exists to determine expected behavior
+            session_file = os.path.expanduser('~/.ssky')
+            if os.path.exists(session_file):
+                # Session file exists - login should succeed using existing session
+                assert isinstance(result, ProfileList), "Should return ProfileList when valid session file exists"
+            else:
+                # No session file - should return error
+                assert isinstance(result, ErrorResult), "Should return ErrorResult when no credentials and no session file"
+                assert result.http_code == 401, "Should return 401 error code"
+                
+        finally:
+            # Restore original environment variable
+            if original_user:
+                os.environ['SSKY_USER'] = original_user
+    
+    def test_07_login_no_credentials_no_session_file(self, login_environment):
+        """Test login behavior when no credentials and no session file are available"""
+        
+        # Temporarily remove SSKY_USER environment variable
+        original_user = os.environ.get('SSKY_USER')
+        if 'SSKY_USER' in os.environ:
+            del os.environ['SSKY_USER']
+        
+        # Clear session state
+        from ssky.ssky_session import SskySession
+        SskySession.clear()
+        
+        # Temporarily remove session file if it exists
+        session_file = os.path.expanduser('~/.ssky')
+        session_backup = None
+        if os.path.exists(session_file):
+            with open(session_file, 'r') as f:
+                session_backup = f.read()
+            os.remove(session_file)
+        
+        try:
+            # Test login without any credentials or session file
+            result = login()
+            assert isinstance(result, ErrorResult), "Should return ErrorResult when no credentials and no session file"
+            assert result.http_code == 401, "Should return 401 error code"
+        finally:
+            # Restore original environment variable
+            if original_user:
+                os.environ['SSKY_USER'] = original_user
+            
+            # Restore session file if it existed
+            if session_backup is not None:
+                with open(session_file, 'w') as f:
+                    f.write(session_backup)

--- a/tests/test_post_and_delete.py
+++ b/tests/test_post_and_delete.py
@@ -1,64 +1,217 @@
 import os
-import sys
+import tempfile
+import pytest
+from unittest.mock import patch, Mock
 from time import sleep
+
 from ssky.delete import delete
 from ssky.post import post
 from ssky.post_data_list import PostDataList
 from ssky.util import join_uri_cid, ErrorResult
-from tests.common import setup, teardown
+from ssky.ssky_session import SskySession
+from tests.common import create_mock_ssky_session, has_credentials
 
-def test_post_quote_reply_delete():
-    setup()
-    print('Dry post...', file=sys.stderr)
-    dry_result = post(message=os.environ.get('SSKY_TEST_POST_TEXT'), image=[os.environ.get('SSKY_TEST_POST_IMAGE')], dry=True)
+@pytest.fixture
+def mock_post_environment():
+    """Setup test environment for post/delete tests"""
+    if not has_credentials():
+        pytest.skip("No credentials available")
     
-    print('Post...', file=sys.stderr)
-    post_result = post(message=os.environ.get('SSKY_TEST_POST_TEXT'), image=[os.environ.get('SSKY_TEST_POST_IMAGE')])
+    # Create mock session for all post/delete tests
+    mock_session, mock_client, mock_profile = create_mock_ssky_session()
     
-    # Check if post failed due to rate limiting or other errors
-    if isinstance(post_result, ErrorResult):
-        print(f'Post failed: {post_result.message} (HTTP {post_result.http_code})', file=sys.stderr)
-        teardown()
-        # For rate limiting errors, we skip the test instead of failing
-        if post_result.http_code == 429:
-            import pytest
-            pytest.skip("Rate limit exceeded - skipping test")
-        else:
-            assert False, f"Post failed: {post_result.message}"
+    # Set up proper mock responses for post/delete functionality
+    # Mock post creation response
+    mock_post_response = Mock()
+    mock_post_response.uri = "at://test.user/app.bsky.feed.post/test123"
+    mock_post_response.cid = "testcid123"
+    mock_client.send_post.return_value = mock_post_response
     
-    source_uri_cid = join_uri_cid(post_result[0].uri, post_result[0].cid)
-    sleep(5)
+    # Mock send_images response (for when images are involved)
+    mock_images_response = Mock()
+    mock_images_response.uri = "at://test.user/app.bsky.feed.post/test123"
+    mock_images_response.cid = "testcid123"
+    mock_client.send_images.return_value = mock_images_response
     
-    print('Quote...', file=sys.stderr)
-    quote_result = post(message=os.environ.get('SSKY_TEST_POST_QUOTE_TEXT'), quote=source_uri_cid)
-    if isinstance(quote_result, ErrorResult):
-        print(f'Quote failed: {quote_result.message} (HTTP {quote_result.http_code})', file=sys.stderr)
-        teardown()
-        if quote_result.http_code == 429:
-            import pytest
-            pytest.skip("Rate limit exceeded - skipping test")
-        else:
-            assert False, f"Quote failed: {quote_result.message}"
+    # Mock get_posts response (for post retrieval after creation)
+    mock_retrieved_post = Mock()
+    mock_retrieved_post.uri = "at://test.user/app.bsky.feed.post/test123"
+    mock_retrieved_post.cid = "testcid123"
+    mock_retrieved_post.author = Mock()
+    mock_retrieved_post.author.did = "did:plc:test123"
+    mock_retrieved_post.author.handle = "test.bsky.social"
+    mock_retrieved_post.record = Mock()
+    mock_retrieved_post.record.text = "Test post message"
     
-    sleep(5)
-    print('Reply...', file=sys.stderr)
-    reply_result = post(message=os.environ.get('SSKY_TEST_POST_REPLY_TEXT'), reply_to=source_uri_cid)
-    if isinstance(reply_result, ErrorResult):
-        print(f'Reply failed: {reply_result.message} (HTTP {reply_result.http_code})', file=sys.stderr)
-        teardown()
-        if reply_result.http_code == 429:
-            import pytest
-            pytest.skip("Rate limit exceeded - skipping test")
-        else:
-            assert False, f"Reply failed: {reply_result.message}"
+    mock_get_posts_response = Mock()
+    mock_get_posts_response.posts = [mock_retrieved_post]
+    mock_client.get_posts.return_value = mock_get_posts_response
     
-    sleep(5)
-    print('Delete reply...', file=sys.stderr)
-    delete_reply_result = delete(reply_result[0].uri)
-    print('Delete quote...', file=sys.stderr)
-    delete_quote_result = delete(quote_result[0].uri)
-    print('Delete post...', file=sys.stderr)
-    delete_post_result = delete(post_result[0].uri)
+    # Mock delete response
+    mock_client.delete_post.return_value = True
+    
+    return mock_session, mock_client, mock_profile
 
-    teardown()
-    assert type(dry_result) is list and type(post_result) is PostDataList and type(quote_result) is PostDataList and type(reply_result) is PostDataList and type(delete_reply_result) is str and type(delete_quote_result) is str and type(delete_post_result) is str
+class TestPostDeleteSequential:
+    """Sequential post and delete tests using mocked SskySession
+    
+    Strategy: 1 real post/delete cycle + mocked tests for other scenarios
+    This reduces API calls and avoids rate limits.
+    """
+    
+    def test_01_post_dry_run(self):
+        """Test dry run functionality without API calls"""
+        # Test dry run - should not make API calls
+        message = os.environ.get('SSKY_TEST_POST_TEXT', 'Test post message')
+        image = os.environ.get('SSKY_TEST_POST_IMAGE')
+        
+        dry_result = post(message=message, image=[image] if image else [], dry=True)
+        
+        # Dry run should return a list (preview)
+        assert isinstance(dry_result, list), "Dry run should return list"
+    
+    def test_02_real_post_quote_reply_delete_cycle(self):
+        """Real API test - post, quote, reply, and delete cycle (only real API test in this file)"""
+        # Skip if no credentials available
+        if not has_credentials():
+            pytest.skip("SSKY_USER environment variable not set")
+        
+        # Skip if SSKY_SKIP_REAL_API_TESTS is set
+        if os.environ.get('SSKY_SKIP_REAL_API_TESTS'):
+            pytest.skip("Real API tests disabled by SSKY_SKIP_REAL_API_TESTS")
+        
+        # This test uses real API calls - no mocking
+        created_posts = []  # Track created posts for cleanup
+        
+        try:
+            # Post with test marker
+            import datetime
+            timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+            message = f"[TEST {timestamp}] {os.environ.get('SSKY_TEST_POST_TEXT', 'Test post message')}"
+            image = os.environ.get('SSKY_TEST_POST_IMAGE')
+            
+            post_result = post(message=message, image=[image] if image else None)
+            
+            # Check if post failed due to rate limiting or other errors
+            if isinstance(post_result, ErrorResult):
+                if post_result.http_code == 429:
+                    pytest.skip("Rate limit exceeded - skipping test")
+                else:
+                    assert False, f"Post failed: {post_result.message}"
+            
+            assert isinstance(post_result, PostDataList), "Post should return PostDataList"
+            created_posts.append(post_result[0].uri)
+            
+            source_uri_cid = join_uri_cid(post_result[0].uri, post_result[0].cid)
+            sleep(5)
+            
+            # Quote with test marker
+            quote_text = f"[TEST {timestamp}] {os.environ.get('SSKY_TEST_POST_QUOTE_TEXT', 'Quote test')}"
+            quote_result = post(message=quote_text, quote=source_uri_cid)
+            if isinstance(quote_result, ErrorResult):
+                if quote_result.http_code == 429:
+                    pytest.skip("Rate limit exceeded - skipping test")
+                else:
+                    assert False, f"Quote failed: {quote_result.message}"
+            
+            assert isinstance(quote_result, PostDataList), "Quote should return PostDataList"
+            created_posts.append(quote_result[0].uri)
+            
+            sleep(5)
+            
+            # Reply with test marker
+            reply_text = f"[TEST {timestamp}] {os.environ.get('SSKY_TEST_POST_REPLY_TEXT', 'Reply test')}"
+            reply_result = post(message=reply_text, reply_to=source_uri_cid)
+            if isinstance(reply_result, ErrorResult):
+                if reply_result.http_code == 429:
+                    pytest.skip("Rate limit exceeded - skipping test")
+                else:
+                    assert False, f"Reply failed: {reply_result.message}"
+            
+            assert isinstance(reply_result, PostDataList), "Reply should return PostDataList"
+            created_posts.append(reply_result[0].uri)
+            
+            sleep(5)
+            
+            # Delete in reverse order (reply -> quote -> original)
+            for uri in reversed(created_posts):
+                delete_result = delete(uri)
+                if isinstance(delete_result, str):
+                    print(f"Successfully deleted: {uri}")
+                else:
+                    print(f"Failed to delete: {uri}")
+            
+        except Exception as e:
+            # Emergency cleanup: try to delete any created posts
+            print(f"Test failed with error: {e}")
+            print("Attempting emergency cleanup of created posts...")
+            for uri in reversed(created_posts):
+                try:
+                    delete_result = delete(uri)
+                    print(f"Emergency cleanup - deleted: {uri}")
+                except Exception as cleanup_error:
+                    print(f"Emergency cleanup failed for {uri}: {cleanup_error}")
+            raise  # Re-raise the original exception
+        
+        finally:
+            SskySession.clear()
+    
+    def test_03_post_with_json_format(self, mock_post_environment):
+        """Test post with JSON format output"""
+        mock_session, mock_client, mock_profile = mock_post_environment
+        
+        with patch('ssky.post.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            # Test with JSON format
+            message = "Test post message"
+            result = post(message=message, format='json')
+            
+            # Should return PostDataList
+            assert isinstance(result, PostDataList), "Should return PostDataList"
+    
+    def test_04_post_error_scenarios(self):
+        """Test error handling scenarios"""
+        # Test 1: No session available
+        with patch('ssky.post.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = None
+            
+            result = post(message="test")
+            assert isinstance(result, ErrorResult), "Post should return ErrorResult when no session available"
+            assert result.http_code == 401, "Should return 401 error code"
+        
+        # Test 2: Empty message with mocked stdin and mocked client
+        import io
+        with patch('sys.stdin', io.StringIO("")):
+            with patch('ssky.post.ssky_client') as mock_ssky_client:
+                mock_session, mock_client, mock_profile = create_mock_ssky_session()
+                
+                # Set up proper string URIs for the mock responses
+                mock_client.send_post.return_value.uri = "at://test.user/app.bsky.feed.post/empty123"
+                mock_client.send_post.return_value.cid = "emptycid123"
+                mock_client.send_images.return_value.uri = "at://test.user/app.bsky.feed.post/empty123"
+                mock_client.send_images.return_value.cid = "emptycid123"
+                
+                # Mock get_posts response with proper string URIs
+                mock_retrieved_post = Mock()
+                mock_retrieved_post.uri = "at://test.user/app.bsky.feed.post/empty123"
+                mock_retrieved_post.cid = "emptycid123"
+                mock_retrieved_post.author = Mock()
+                mock_retrieved_post.author.did = "did:plc:test123"
+                mock_retrieved_post.author.handle = "test.bsky.social"
+                mock_retrieved_post.record = Mock()
+                mock_retrieved_post.record.text = ""
+                
+                mock_get_posts_response = Mock()
+                mock_get_posts_response.posts = [mock_retrieved_post]
+                mock_client.get_posts.return_value = mock_get_posts_response
+                
+                mock_ssky_client.return_value = mock_client
+                
+                result = post(message="")
+                # Empty message creates a valid post when mocked
+                assert isinstance(result, PostDataList), "Post should return PostDataList even with empty message"
+        
+        # Test 3: Test delete with invalid URI
+        result = delete("invalid://uri")
+        assert isinstance(result, ErrorResult), "Delete should return ErrorResult with invalid URI"

--- a/tests/test_post_and_delete.py
+++ b/tests/test_post_and_delete.py
@@ -4,22 +4,54 @@ from time import sleep
 from ssky.delete import delete
 from ssky.post import post
 from ssky.post_data_list import PostDataList
-from ssky.util import join_uri_cid
+from ssky.util import join_uri_cid, ErrorResult
 from tests.common import setup, teardown
 
 def test_post_quote_reply_delete():
     setup()
     print('Dry post...', file=sys.stderr)
     dry_result = post(message=os.environ.get('SSKY_TEST_POST_TEXT'), image=[os.environ.get('SSKY_TEST_POST_IMAGE')], dry=True)
+    
     print('Post...', file=sys.stderr)
     post_result = post(message=os.environ.get('SSKY_TEST_POST_TEXT'), image=[os.environ.get('SSKY_TEST_POST_IMAGE')])
+    
+    # Check if post failed due to rate limiting or other errors
+    if isinstance(post_result, ErrorResult):
+        print(f'Post failed: {post_result.message} (HTTP {post_result.http_code})', file=sys.stderr)
+        teardown()
+        # For rate limiting errors, we skip the test instead of failing
+        if post_result.http_code == 429:
+            import pytest
+            pytest.skip("Rate limit exceeded - skipping test")
+        else:
+            assert False, f"Post failed: {post_result.message}"
+    
     source_uri_cid = join_uri_cid(post_result[0].uri, post_result[0].cid)
     sleep(5)
+    
     print('Quote...', file=sys.stderr)
     quote_result = post(message=os.environ.get('SSKY_TEST_POST_QUOTE_TEXT'), quote=source_uri_cid)
+    if isinstance(quote_result, ErrorResult):
+        print(f'Quote failed: {quote_result.message} (HTTP {quote_result.http_code})', file=sys.stderr)
+        teardown()
+        if quote_result.http_code == 429:
+            import pytest
+            pytest.skip("Rate limit exceeded - skipping test")
+        else:
+            assert False, f"Quote failed: {quote_result.message}"
+    
     sleep(5)
     print('Reply...', file=sys.stderr)
-    reply_result = post(message=os.environ.get('SSKY_TEST_POST_REPLY_TEXT'), reply=source_uri_cid)
+    reply_result = post(message=os.environ.get('SSKY_TEST_POST_REPLY_TEXT'), reply_to=source_uri_cid)
+    if isinstance(reply_result, ErrorResult):
+        print(f'Reply failed: {reply_result.message} (HTTP {reply_result.http_code})', file=sys.stderr)
+        teardown()
+        if reply_result.http_code == 429:
+            import pytest
+            pytest.skip("Rate limit exceeded - skipping test")
+        else:
+            assert False, f"Reply failed: {reply_result.message}"
+    
     sleep(5)
     print('Delete reply...', file=sys.stderr)
     delete_reply_result = delete(reply_result[0].uri)

--- a/tests/test_post_data_list.py
+++ b/tests/test_post_data_list.py
@@ -1,0 +1,682 @@
+import os
+import tempfile
+import json
+import pytest
+from unittest.mock import Mock, patch
+from datetime import datetime
+
+from ssky.post_data_list import PostDataList
+from atproto_client import models
+
+
+@pytest.fixture
+def mock_post_data_environment():
+    """Fixture for PostDataList tests with mock posts"""
+    test_uri1 = "at://did:plc:test123/app.bsky.feed.post/test1"
+    test_uri2 = "at://did:plc:test456/app.bsky.feed.post/test2"
+    test_cid1 = "bafyreicid1"
+    test_cid2 = "bafyreicid2"
+    
+    # Create mock posts
+    mock_post1 = Mock(spec=models.AppBskyFeedDefs.PostView)
+    mock_post1.uri = test_uri1
+    mock_post1.cid = test_cid1
+    
+    # Mock author
+    mock_author1 = Mock()
+    mock_author1.did = "did:plc:test123"
+    mock_author1.handle = "test1.bsky.social"
+    mock_author1.display_name = "Test User 1"
+    mock_author1.avatar = "https://example.com/avatar1.jpg"
+    mock_post1.author = mock_author1
+    
+    # Mock record
+    mock_record1 = Mock()
+    mock_record1.text = "This is a test post"
+    mock_record1.created_at = "2023-01-01T00:00:00.000Z"
+    mock_record1.facets = None  # No facets for simple test
+    mock_post1.record = mock_record1
+    
+    # Mock indexed_at
+    mock_post1.indexed_at = "2023-01-01T01:00:00.000Z"
+    
+    # Mock reply_count, repost_count, like_count
+    mock_post1.reply_count = 5
+    mock_post1.repost_count = 10
+    mock_post1.like_count = 15
+    mock_post1.viewer = None  # No viewer info for simple test
+    
+    # Create second mock post
+    mock_post2 = Mock(spec=models.AppBskyFeedDefs.PostView)
+    mock_post2.uri = test_uri2
+    mock_post2.cid = test_cid2
+    
+    mock_author2 = Mock()
+    mock_author2.did = "did:plc:test456"
+    mock_author2.handle = "test2.bsky.social"
+    mock_author2.display_name = "Test User 2"
+    mock_author2.avatar = "https://example.com/avatar2.jpg"
+    mock_post2.author = mock_author2
+    
+    mock_record2 = Mock()
+    mock_record2.text = "Another test post"
+    mock_record2.created_at = "2023-02-01T00:00:00.000Z"
+    mock_record2.facets = None  # No facets for simple test
+    mock_post2.record = mock_record2
+    
+    mock_post2.indexed_at = "2023-02-01T01:00:00.000Z"
+    mock_post2.reply_count = 0
+    mock_post2.repost_count = 0
+    mock_post2.like_count = 0
+    mock_post2.viewer = None  # No viewer info for simple test
+    
+    return {
+        'test_uri1': test_uri1,
+        'test_uri2': test_uri2,
+        'test_cid1': test_cid1,
+        'test_cid2': test_cid2,
+        'mock_post1': mock_post1,
+        'mock_post2': mock_post2,
+        'mock_author1': mock_author1,
+        'mock_author2': mock_author2,
+        'mock_record1': mock_record1,
+        'mock_record2': mock_record2,
+    }
+
+
+class TestPostDataList:
+
+    def test_post_data_list_basic_operations(self, mock_post_data_environment):
+        """Test basic PostDataList operations"""
+        env = mock_post_data_environment
+        post_list = PostDataList()
+        
+        # Test initial state
+        assert len(post_list) == 0
+        assert str(post_list) == "[]"
+        
+        # Test append
+        result = post_list.append(env['mock_post1'])
+        assert result is post_list  # Should return self for chaining
+        assert len(post_list) == 1
+        assert post_list[0] == env['mock_post1']
+        
+        # Test append multiple
+        post_list.append(env['mock_post2'])
+        assert len(post_list) == 2
+        assert post_list[1] == env['mock_post2']
+        
+        # Test iteration
+        posts = list(post_list)
+        assert posts == [env['mock_post1'], env['mock_post2']]
+
+    def test_post_data_list_custom_delimiter(self):
+        """Test custom delimiter functionality"""
+        # Test class-level delimiter
+        original_delimiter = PostDataList.get_default_delimiter()
+        PostDataList.set_default_delimiter('|')
+        assert PostDataList.get_default_delimiter() == '|'
+        
+        # Test instance-level delimiter
+        post_list = PostDataList(default_delimiter=',')
+        assert post_list.default_delimiter == ','
+        
+        # Restore original delimiter
+        PostDataList.set_default_delimiter(original_delimiter)
+
+    def test_post_data_list_duplicate_handling(self, mock_post_data_environment):
+        """Test PostDataList duplicate handling"""
+        env = mock_post_data_environment
+        post_list = PostDataList()
+        
+        # Add same post twice
+        post_list.append(env['mock_post1'])
+        post_list.append(env['mock_post1'])
+        
+        # Should only contain one instance
+        assert len(post_list) == 1
+        assert post_list[0] == env['mock_post1']
+
+    def test_post_item_basic_functionality(self, mock_post_data_environment):
+        """Test PostDataList.Item basic functionality"""
+        env = mock_post_data_environment
+        item = PostDataList.Item(env['mock_post1'])
+        
+        # Test id (should return URI::CID format)
+        expected_id = f"{env['test_uri1']}::{env['test_cid1']}"
+        assert item.id() == expected_id
+        
+        # Test text_only
+        assert item.text_only() == "This is a test post"
+
+    def test_post_item_short_format(self, mock_post_data_environment):
+        """Test PostDataList.Item short format"""
+        env = mock_post_data_environment
+        item = PostDataList.Item(env['mock_post1'])
+        
+        # Test default delimiter
+        short_output = item.short()
+        expected_parts = [
+            f"{env['test_uri1']}::{env['test_cid1']}",  # URI::CID format
+            "did:plc:test123",  # author DID
+            "test1.bsky.social",  # author handle
+            "Test_User_1",  # summarized display name
+            "This_is_a_test_post"  # summarized text
+        ]
+        assert short_output == " ".join(expected_parts)
+        
+        # Test custom delimiter
+        short_output_custom = item.short(delimiter="|")
+        assert short_output_custom == "|".join(expected_parts)
+
+    def test_post_item_long_format(self, mock_post_data_environment):
+        """Test PostDataList.Item long format"""
+        env = mock_post_data_environment
+        item = PostDataList.Item(env['mock_post1'])
+        long_output = item.long()
+        
+        expected_lines = [
+            "Author-DID: did:plc:test123",
+            "Author-Display-Name: Test User 1",
+            "Author-Handle: test1.bsky.social",
+            "Created-At: 2023-01-01T00:00:00.000Z",
+            "Record-CID: bafyreicid1",
+            "Record-URI: at://did:plc:test123/app.bsky.feed.post/test1",
+            "",
+            "This is a test post"
+        ]
+        assert long_output == "\n".join(expected_lines)
+
+    def test_post_item_json_format(self, mock_post_data_environment):
+        """Test PostDataList.Item JSON format"""
+        env = mock_post_data_environment
+        item = PostDataList.Item(env['mock_post1'])
+        
+        with patch('atproto_client.models.utils.get_model_as_json') as mock_json:
+            mock_json.return_value = '{"test": "json"}'
+            json_output = item.json()
+            assert json_output == '{"test": "json"}'
+            mock_json.assert_called_once_with(env['mock_post1'])
+
+    def test_post_item_simple_json_format(self, mock_post_data_environment):
+        """Test PostDataList.Item simple JSON format"""
+        env = mock_post_data_environment
+        item = PostDataList.Item(env['mock_post1'])
+        simple_json_output = item.simple_json()
+        
+        # Parse the JSON to verify structure
+        parsed = json.loads(simple_json_output)
+        assert parsed["status"] == "ok"
+        assert "data" in parsed
+        
+        data = parsed["data"]
+        assert data["uri"] == env['test_uri1']
+        assert data["cid"] == env['test_cid1']
+        assert data["author"]["handle"] == "test1.bsky.social"
+        assert data["author"]["display_name"] == "Test User 1"
+        assert data["text"] == "This is a test post"
+        assert data["created_at"] == "2023-01-01T00:00:00.000Z"
+        assert data["indexed_at"] == "2023-01-01T01:00:00.000Z"
+        assert data["reply_count"] == 5
+        assert data["repost_count"] == 10
+        assert data["like_count"] == 15
+
+    def test_post_item_printable_formats(self, mock_post_data_environment):
+        """Test PostDataList.Item printable method with different formats"""
+        env = mock_post_data_environment
+        item = PostDataList.Item(env['mock_post1'])
+        
+        # Test id format
+        expected_id = f"{env['test_uri1']}::{env['test_cid1']}"
+        assert item.printable('id') == expected_id
+        
+        # Test long format
+        long_output = item.printable('long')
+        assert "Author-DID: did:plc:test123" in long_output
+        
+        # Test text format
+        assert item.printable('text') == "This is a test post"
+        
+        # Test json format
+        with patch('atproto_client.models.utils.get_model_as_json') as mock_json:
+            mock_json.return_value = '{"test": "json"}'
+            assert item.printable('json') == '{"test": "json"}'
+        
+        # Test simple_json format
+        simple_json_output = item.printable('simple_json')
+        parsed = json.loads(simple_json_output)
+        assert parsed["status"] == "ok"
+        
+        # Test default (short) format
+        short_output = item.printable('short')
+        assert env['test_uri1'] in short_output
+        assert "test1.bsky.social" in short_output
+
+    def test_post_item_filename_generation(self, mock_post_data_environment):
+        """Test PostDataList.Item filename generation"""
+        env = mock_post_data_environment
+        item = PostDataList.Item(env['mock_post1'])
+        filename = item.get_filename()
+        # Should use handle.datetime.txt format
+        expected_filename = "test1.bsky.social.20230101000000.txt"
+        assert filename == expected_filename
+
+
+
+
+
+    def test_post_data_list_print_console_output(self, mock_post_data_environment):
+        """Test PostDataList print method for console output"""
+        env = mock_post_data_environment
+        post_list = PostDataList()
+        post_list.items = [
+            PostDataList.Item(env['mock_post1']),
+            PostDataList.Item(env['mock_post2'])
+        ]
+        
+        # Test simple_json format (special case)
+        with patch('builtins.print') as mock_print:
+            post_list.print('simple_json')
+            
+            # Should print a single JSON response with all posts
+            mock_print.assert_called_once()
+            printed_content = mock_print.call_args[0][0]
+            parsed = json.loads(printed_content)
+            assert parsed["status"] == "ok"
+            assert len(parsed["data"]) == 2
+
+    def test_post_data_list_print_long_format_with_separator(self, mock_post_data_environment):
+        """Test PostDataList print method with long format separator"""
+        env = mock_post_data_environment
+        post_list = PostDataList()
+        post_list.items = [
+            PostDataList.Item(env['mock_post1']),
+            PostDataList.Item(env['mock_post2'])
+        ]
+        
+        with patch('builtins.print') as mock_print:
+            post_list.print('long')
+            
+            # Should print: item1, separator, item2
+            assert mock_print.call_count == 3
+            # Check that separator was printed
+            separator_call = mock_print.call_args_list[1]
+            assert separator_call[0][0] == '----------------'
+
+    def test_post_data_list_print_file_output(self, mock_post_data_environment):
+        """Test PostDataList print method for file output"""
+        env = mock_post_data_environment
+        post_list = PostDataList()
+        post_list.items = [
+            PostDataList.Item(env['mock_post1']),
+            PostDataList.Item(env['mock_post2'])
+        ]
+        
+        # Create temporary directory
+        with tempfile.TemporaryDirectory() as temp_dir:
+            post_list.print('short', output=temp_dir)
+            
+            # Check that files were created
+            expected_files = [
+                "test1.bsky.social.20230101000000.txt",
+                "test2.bsky.social.20230201000000.txt"
+            ]
+            
+            for filename in expected_files:
+                filepath = os.path.join(temp_dir, filename)
+                assert os.path.exists(filepath)
+                
+                # Check file content
+                with open(filepath, 'r') as f:
+                    content = f.read().strip()
+                    if filename == "test1.bsky.social.20230101000000.txt":
+                        assert env['test_uri1'] in content
+                        assert "test1.bsky.social" in content
+                        assert "This_is_a_test_post" in content  # summarized text
+                    else:
+                        assert env['test_uri2'] in content
+                        assert "test2.bsky.social" in content
+                        assert "Another_test_post" in content  # summarized text
+
+    def test_post_data_list_print_file_output_with_custom_delimiter(self, mock_post_data_environment):
+        """Test PostDataList print method for file output with custom delimiter"""
+        env = mock_post_data_environment
+        post_list = PostDataList()
+        post_list.items = [PostDataList.Item(env['mock_post1'])]
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            post_list.print('short', output=temp_dir, delimiter='|')
+            
+            filepath = os.path.join(temp_dir, "test1.bsky.social.20230101000000.txt")
+            with open(filepath, 'r') as f:
+                content = f.read().strip()
+                # Should use custom delimiter
+                assert '|' in content
+                assert env['test_uri1'] in content
+
+    def test_post_data_list_edge_cases(self, mock_post_data_environment):
+        """Test PostDataList edge cases"""
+        env = mock_post_data_environment
+        # Test empty list
+        empty_list = PostDataList()
+        assert len(empty_list) == 0
+        
+        # Test multiple appends of same item (should not duplicate)
+        post_list = PostDataList()
+        post_list.append(env['mock_post1'])
+        post_list.append(env['mock_post1'])  # Same post again
+        
+        # Should only contain one instance
+        assert len(post_list) == 1
+
+    def test_post_item_with_missing_attributes(self, mock_post_data_environment):
+        """Test PostDataList.Item with missing attributes"""
+        env = mock_post_data_environment
+        # Create mock post with minimal attributes
+        minimal_post = Mock()
+        minimal_post.uri = env['test_uri1']
+        minimal_post.cid = env['test_cid1']
+        
+        # Mock author with minimal info
+        minimal_author = Mock()
+        minimal_author.did = "did:plc:minimal123"
+        minimal_author.handle = "minimal.bsky.social"
+        minimal_author.display_name = None
+        minimal_author.avatar = None
+        minimal_post.author = minimal_author
+        
+        # Mock record with minimal info
+        minimal_record = Mock()
+        minimal_record.text = "Minimal post"
+        minimal_record.created_at = "2023-01-01T00:00:00.000Z"
+        minimal_record.facets = None
+        minimal_post.record = minimal_record
+        
+        minimal_post.indexed_at = None
+        minimal_post.reply_count = None
+        minimal_post.repost_count = None
+        minimal_post.like_count = None
+        
+        item = PostDataList.Item(minimal_post)
+        
+        # Test that it handles None values gracefully
+        simple_json_output = item.simple_json()
+        parsed = json.loads(simple_json_output)
+        data = parsed["data"]
+        
+        assert data["author"]["display_name"] is None
+        assert data["indexed_at"] is None
+        assert data["reply_count"] is None
+        assert data["repost_count"] is None
+        assert data["like_count"] is None
+
+    def test_post_item_facets_url_processing(self, mock_post_data_environment):
+        """Test PostDataList.Item URL processing from facets"""
+        env = mock_post_data_environment
+        # Create mock post with facets containing URL
+        faceted_post = Mock()
+        faceted_post.uri = env['test_uri1']
+        faceted_post.cid = env['test_cid1']
+        
+        # Mock author
+        faceted_author = Mock()
+        faceted_author.did = "did:plc:test123"
+        faceted_author.handle = "test.bsky.social"
+        faceted_author.display_name = "Test User"
+        faceted_author.avatar = None
+        faceted_post.author = faceted_author
+        
+        # Mock record with truncated URL and facets
+        faceted_record = Mock()
+        faceted_record.text = "Check out this link: example.com/..."
+        faceted_record.created_at = "2023-01-01T00:00:00.000Z"
+        
+        # Mock facets with URL restoration info
+        mock_facet = Mock()
+        mock_facet.index = Mock()
+        mock_facet.index.byte_start = 23  # Position of "example.com/..."
+        mock_facet.index.byte_end = 37    # End of truncated text
+        
+        mock_feature = Mock()
+        mock_feature.uri = "https://example.com/full-url-path"
+        mock_facet.features = [mock_feature]
+        
+        faceted_record.facets = [mock_facet]
+        faceted_post.record = faceted_record
+        
+        # Mock other attributes
+        faceted_post.indexed_at = "2023-01-01T01:00:00.000Z"
+        faceted_post.reply_count = 0
+        faceted_post.repost_count = 0
+        faceted_post.like_count = 0
+        faceted_post.viewer = None
+        
+        item = PostDataList.Item(faceted_post)
+        
+        # Test that text_only processes URLs from facets
+        processed_text = item.text_only()
+        assert "https://example.com/full-url-path" in processed_text
+        assert "example.com/..." not in processed_text
+        
+        # Test that simple_json also includes processed text
+        simple_json_output = item.simple_json()
+        parsed = json.loads(simple_json_output)
+        data = parsed["data"]
+        assert "https://example.com/full-url-path" in data["text"]
+
+    def test_post_item_facets_no_facets(self, mock_post_data_environment):
+        """Test PostDataList.Item with no facets (should return original text)"""
+        env = mock_post_data_environment
+        item = PostDataList.Item(env['mock_post1'])
+        
+        # Should return original text when no facets
+        assert item.text_only() == "This is a test post"
+
+    def test_post_item_facets_empty_facets(self, mock_post_data_environment):
+        """Test PostDataList.Item with empty facets list"""
+        env = mock_post_data_environment
+        # Create post with empty facets
+        post_with_empty_facets = Mock()
+        post_with_empty_facets.uri = env['test_uri1']
+        post_with_empty_facets.cid = env['test_cid1']
+        post_with_empty_facets.author = env['mock_author1']
+        
+        record_with_empty_facets = Mock()
+        record_with_empty_facets.text = "No URLs here"
+        record_with_empty_facets.created_at = "2023-01-01T00:00:00.000Z"
+        record_with_empty_facets.facets = []  # Empty list
+        post_with_empty_facets.record = record_with_empty_facets
+        
+        post_with_empty_facets.indexed_at = None
+        post_with_empty_facets.reply_count = 0
+        post_with_empty_facets.repost_count = 0
+        post_with_empty_facets.like_count = 0
+        post_with_empty_facets.viewer = None
+        
+        item = PostDataList.Item(post_with_empty_facets)
+        
+        # Should return original text
+        assert item.text_only() == "No URLs here"
+
+    def test_post_item_facets_non_url_facets(self, mock_post_data_environment):
+        """Test PostDataList.Item with facets that are not URLs (mentions, tags)"""
+        env = mock_post_data_environment
+        # Create post with mention facets (should be ignored)
+        post_with_mentions = Mock()
+        post_with_mentions.uri = env['test_uri1']
+        post_with_mentions.cid = env['test_cid1']
+        post_with_mentions.author = env['mock_author1']
+        
+        mention_record = Mock()
+        mention_record.text = "Hello @user this is a mention"
+        mention_record.created_at = "2023-01-01T00:00:00.000Z"
+        
+        # Mock mention facet (should be ignored by URL processing)
+        mock_mention_facet = Mock()
+        mock_mention_facet.index = Mock()
+        mock_mention_facet.index.byte_start = 6
+        mock_mention_facet.index.byte_end = 11
+        
+        mock_mention_feature = Mock(spec=[])  # Empty spec means no attributes
+        # Mention features don't have 'uri' attribute, they have 'did'
+        mock_mention_feature.did = "did:plc:mentioned-user"
+        mock_mention_facet.features = [mock_mention_feature]
+        
+        mention_record.facets = [mock_mention_facet]
+        post_with_mentions.record = mention_record
+        
+        post_with_mentions.indexed_at = None
+        post_with_mentions.reply_count = 0
+        post_with_mentions.repost_count = 0
+        post_with_mentions.like_count = 0
+        post_with_mentions.viewer = None
+        
+        item = PostDataList.Item(post_with_mentions)
+        
+        # Should return original text since mention facets are ignored
+        assert item.text_only() == "Hello @user this is a mention"
+
+    def test_post_item_facets_multiple_urls(self, mock_post_data_environment):
+        """Test PostDataList.Item with multiple URL facets"""
+        env = mock_post_data_environment
+        # Create post with multiple URLs
+        multi_url_post = Mock()
+        multi_url_post.uri = env['test_uri1']
+        multi_url_post.cid = env['test_cid1']
+        multi_url_post.author = env['mock_author1']
+        
+        multi_url_record = Mock()
+        multi_url_record.text = "Visit example.com/... and also check.com/..."
+        multi_url_record.created_at = "2023-01-01T00:00:00.000Z"
+        
+        # Mock first URL facet
+        mock_facet1 = Mock()
+        mock_facet1.index = Mock()
+        mock_facet1.index.byte_start = 6   # Position of first "example.com/..."
+        mock_facet1.index.byte_end = 20    # End of first truncated URL
+        
+        mock_feature1 = Mock()
+        mock_feature1.uri = "https://example.com/full-path"
+        mock_facet1.features = [mock_feature1]
+        
+        # Mock second URL facet
+        mock_facet2 = Mock()
+        mock_facet2.index = Mock()
+        mock_facet2.index.byte_start = 35  # Position of second "check.com/..."
+        mock_facet2.index.byte_end = 47    # End of second truncated URL
+        
+        mock_feature2 = Mock()
+        mock_feature2.uri = "https://check.com/another-path"
+        mock_facet2.features = [mock_feature2]
+        
+        multi_url_record.facets = [mock_facet1, mock_facet2]
+        multi_url_post.record = multi_url_record
+        
+        multi_url_post.indexed_at = None
+        multi_url_post.reply_count = 0
+        multi_url_post.repost_count = 0
+        multi_url_post.like_count = 0
+        multi_url_post.viewer = None
+        
+        item = PostDataList.Item(multi_url_post)
+        
+        # Test that both URLs are processed
+        processed_text = item.text_only()
+        assert "https://example.com/full-path" in processed_text
+        assert "https://check.com/another-path" in processed_text
+        assert "example.com/..." not in processed_text
+        assert "check.com/..." not in processed_text
+
+    def test_post_item_facets_mixed_features(self, mock_post_data_environment):
+        """Test PostDataList.Item with mixed facet features (URL + mention)"""
+        env = mock_post_data_environment
+        # Create post with both URL and mention in same facet
+        mixed_post = Mock()
+        mixed_post.uri = env['test_uri1']
+        mixed_post.cid = env['test_cid1']
+        mixed_post.author = env['mock_author1']
+        
+        mixed_record = Mock()
+        mixed_record.text = "Check example.com/... and @user"
+        mixed_record.created_at = "2023-01-01T00:00:00.000Z"
+        
+        # Mock facet with URL feature
+        mock_url_facet = Mock()
+        mock_url_facet.index = Mock()
+        mock_url_facet.index.byte_start = 6
+        mock_url_facet.index.byte_end = 20
+        
+        mock_url_feature = Mock()
+        mock_url_feature.uri = "https://example.com/full-url"
+        mock_url_facet.features = [mock_url_feature]
+        
+        # Mock facet with mention feature
+        mock_mention_facet = Mock()
+        mock_mention_facet.index = Mock()
+        mock_mention_facet.index.byte_start = 25
+        mock_mention_facet.index.byte_end = 30
+        
+        mock_mention_feature = Mock(spec=[])  # Empty spec means no attributes
+        mock_mention_feature.did = "did:plc:user123"
+        mock_mention_facet.features = [mock_mention_feature]
+        
+        mixed_record.facets = [mock_url_facet, mock_mention_facet]
+        mixed_post.record = mixed_record
+        
+        mixed_post.indexed_at = None
+        mixed_post.reply_count = 0
+        mixed_post.repost_count = 0
+        mixed_post.like_count = 0
+        mixed_post.viewer = None
+        
+        item = PostDataList.Item(mixed_post)
+        
+        # Test that only URL is processed, mention is left as-is
+        processed_text = item.text_only()
+        assert "https://example.com/full-url" in processed_text
+        assert "@user" in processed_text  # Mention should remain unchanged
+        assert "example.com/..." not in processed_text
+
+    def test_post_item_facets_unicode_handling(self, mock_post_data_environment):
+        """Test PostDataList.Item facets with Unicode text"""
+        env = mock_post_data_environment
+        # Create post with Unicode characters and URL
+        unicode_post = Mock()
+        unicode_post.uri = env['test_uri1']
+        unicode_post.cid = env['test_cid1']
+        unicode_post.author = env['mock_author1']
+        
+        unicode_record = Mock()
+        unicode_record.text = "こんにちは example.com/... 世界"
+        unicode_record.created_at = "2023-01-01T00:00:00.000Z"
+        
+        # Mock facet with URL (note: byte positions must account for UTF-8 encoding)
+        mock_facet = Mock()
+        mock_facet.index = Mock()
+        # "こんにちは " is 18 bytes in UTF-8 (6 chars × 3 bytes each)
+        mock_facet.index.byte_start = 18
+        mock_facet.index.byte_end = 32  # "example.com/..." is 14 bytes
+        
+        mock_feature = Mock()
+        mock_feature.uri = "https://example.com/unicode-test"
+        mock_facet.features = [mock_feature]
+        
+        unicode_record.facets = [mock_facet]
+        unicode_post.record = unicode_record
+        
+        unicode_post.indexed_at = None
+        unicode_post.reply_count = 0
+        unicode_post.repost_count = 0
+        unicode_post.like_count = 0
+        unicode_post.viewer = None
+        
+        item = PostDataList.Item(unicode_post)
+        
+        # Test that Unicode text is handled correctly
+        processed_text = item.text_only()
+        assert "こんにちは" in processed_text
+        assert "世界" in processed_text
+        assert "https://example.com/unicode-test" in processed_text
+        assert "example.com/..." not in processed_text
+
+ 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,28 +1,173 @@
 import os
+import tempfile
+import pytest
+from unittest.mock import patch, Mock
+
 from ssky.profile import profile
 from ssky.profile_list import ProfileList
-from tests.common import setup, teardown
+from ssky.util import ErrorResult
+from tests.common import (
+    create_mock_ssky_session, has_credentials
+)
 
-def test_profile_handle():
-    setup()
-    result = profile(os.environ.get('SSKY_TEST_HANDLE'))
-    teardown()
-    assert type(result) is ProfileList
+@pytest.fixture
+def mock_profile_environment():
+    """Setup test environment for profile tests"""
+    if not has_credentials():
+        pytest.skip("No credentials available")
+    
+    # Create mock session for all profile tests
+    mock_session, mock_client, mock_profile = create_mock_ssky_session()
+    return mock_session, mock_client, mock_profile
 
-def test_profile_did():
-    setup()
-    result = profile(os.environ.get('SSKY_TEST_DID'))
-    teardown()
-    assert type(result) is ProfileList
+@pytest.fixture
+def mock_profile_response():
+    """Create a standard mock profile response"""
+    mock_response = Mock()
+    mock_response.did = "did:plc:test123"
+    mock_response.handle = "test.bsky.social"
+    mock_response.display_name = "Test User"
+    mock_response.description = "Test description"
+    mock_response.avatar = "https://example.com/avatar.jpg"
+    mock_response.banner = None
+    mock_response.followers_count = 100
+    mock_response.follows_count = 50
+    mock_response.posts_count = 25
+    mock_response.created_at = "2023-01-01T00:00:00.000Z"
+    mock_response.indexed_at = "2023-01-01T01:00:00.000Z"
+    return mock_response
 
-def test_profile_invalid_handle():
-    setup()
-    result = profile(os.environ.get('SSKY_TEST_INVALID_HANDLE'))
-    teardown()
-    assert result is None
-
-def test_profile_invalid_did():
-    setup()
-    result = profile(os.environ.get('SSKY_TEST_INVALID_DID'))
-    teardown()
-    assert result is None
+class TestProfileSequential:
+    """Sequential profile tests using mocked SskySession
+    
+    Strategy: Mock SskySession to avoid API calls while testing profile function logic
+    """
+    
+    def test_01_profile_by_handle(self, mock_profile_environment, mock_profile_response):
+        """Test get profile by handle using mocked session"""
+        
+        mock_session, mock_client, mock_profile = mock_profile_environment
+        
+        # Set up mock client response
+        mock_client.get_profile.return_value = mock_profile_response
+        
+        with patch('ssky.profile.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            handle = "test.bsky.social"
+            result = profile(handle)
+            
+            assert isinstance(result, ProfileList), "Profile by handle should return ProfileList"
+            
+            # Verify ssky_client was called
+            mock_ssky_client.assert_called_once()
+            
+            # Verify client.get_profile was called with correct parameter
+            mock_client.get_profile.assert_called_once()
+            
+    
+    def test_02_profile_by_did(self, mock_profile_environment, mock_profile_response):
+        """Test get profile by DID using mocked session"""
+        
+        mock_session, mock_client, mock_profile = mock_profile_environment
+        
+        # Set up mock client response
+        mock_client.get_profile.return_value = mock_profile_response
+        
+        with patch('ssky.profile.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            did = os.environ.get('SSKY_TEST_DID', 'did:plc:test123')
+            result = profile(did)
+            
+            assert isinstance(result, ProfileList), "Profile by DID should return ProfileList"
+            
+            # Verify ssky_client was called
+            mock_ssky_client.assert_called_once()
+            
+            # Verify client.get_profile was called
+            mock_client.get_profile.assert_called_once()
+        
+    
+    def test_03_profile_invalid_handle(self, mock_profile_environment):
+        """Test get profile with invalid handle"""
+        
+        mock_session, mock_client, mock_profile = mock_profile_environment
+        
+        # Mock exception for invalid handle
+        import atproto_client
+        mock_client.get_profile.side_effect = atproto_client.exceptions.AtProtocolError("Profile not found")
+        
+        with patch('ssky.profile.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            invalid_handle = os.environ.get('SSKY_TEST_INVALID_HANDLE', 'invalid.handle.test')
+            result = profile(invalid_handle)
+            
+            assert isinstance(result, ErrorResult), "Profile with invalid handle should return ErrorResult"
+        
+    
+    def test_04_profile_invalid_did(self, mock_profile_environment):
+        """Test get profile with invalid DID"""
+        
+        mock_session, mock_client, mock_profile = mock_profile_environment
+        
+        # Mock exception for invalid DID
+        import atproto_client
+        mock_client.get_profile.side_effect = atproto_client.exceptions.AtProtocolError("Profile not found")
+        
+        with patch('ssky.profile.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            invalid_did = os.environ.get('SSKY_TEST_INVALID_DID', 'did:plc:invalid123')
+            result = profile(invalid_did)
+            
+            assert isinstance(result, ErrorResult), "Profile with invalid DID should return ErrorResult"
+        
+    
+    def test_05_profile_error_scenarios(self):
+        """Test error handling scenarios"""
+        
+        # Test 1: No session available (ssky_client returns None)
+        with patch('ssky.profile.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = None
+            
+            result = profile("test.bsky.social")
+            assert isinstance(result, ErrorResult), "Profile should return ErrorResult when no session available"
+            assert result.http_code == 401, "Profile should return 401 error code"
+        
+        # Test 2: Empty identifier
+        result = profile("")
+        assert isinstance(result, ErrorResult), "Profile should return ErrorResult with empty identifier"
+        
+    
+    def test_06_profile_with_json_format(self, mock_profile_environment, mock_profile_response):
+        """Test profile with JSON format output"""
+        
+        mock_session, mock_client, mock_profile = mock_profile_environment
+        
+        # Set up mock client response
+        mock_client.get_profile.return_value = mock_profile_response
+        
+        with patch('ssky.profile.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            handle = os.environ.get('SSKY_TEST_HANDLE', 'test.bsky.social')
+            result = profile(handle, format='json')
+            
+            assert isinstance(result, ProfileList), "Profile should return ProfileList with JSON format"
+        
+    
+    def test_07_profile_login_required_error(self):
+        """Test profile when LoginRequiredError is raised"""
+        
+        # Mock ssky_client to raise LoginRequiredError
+        import atproto_client
+        
+        with patch('ssky.profile.ssky_client') as mock_ssky_client:
+            mock_ssky_client.side_effect = atproto_client.exceptions.LoginRequiredError("Login required")
+            
+            result = profile("test.bsky.social")
+            assert isinstance(result, ErrorResult), "Profile should return ErrorResult on LoginRequiredError"
+            assert result.http_code == 401, "Profile should return 401 error code"
+        

--- a/tests/test_profile_list.py
+++ b/tests/test_profile_list.py
@@ -1,0 +1,424 @@
+import os
+import tempfile
+import shutil
+import json
+import pytest
+from unittest.mock import Mock, patch
+from datetime import datetime
+
+from ssky.profile_list import ProfileList
+from ssky.util import create_success_response
+from atproto_client import models
+
+
+@pytest.fixture
+def mock_profile_list_environment():
+    """Fixture for ProfileList tests with mock profiles"""
+    test_did1 = "did:plc:test123"
+    test_did2 = "did:plc:test456"
+    test_handle1 = "test1.bsky.social"
+    test_handle2 = "test2.bsky.social"
+    
+    # Create mock profiles
+    mock_profile1 = Mock(spec=models.AppBskyActorDefs.ProfileViewDetailed)
+    mock_profile1.did = test_did1
+    mock_profile1.handle = test_handle1
+    mock_profile1.display_name = "Test User 1"
+    mock_profile1.description = "This is a test user description"
+    mock_profile1.avatar = "https://example.com/avatar1.jpg"
+    mock_profile1.banner = "https://example.com/banner1.jpg"
+    mock_profile1.followers_count = 100
+    mock_profile1.follows_count = 50
+    mock_profile1.posts_count = 25
+    mock_profile1.created_at = "2023-01-01T00:00:00.000Z"
+    mock_profile1.indexed_at = "2023-01-01T01:00:00.000Z"
+    
+    mock_profile2 = Mock(spec=models.AppBskyActorDefs.ProfileViewDetailed)
+    mock_profile2.did = test_did2
+    mock_profile2.handle = test_handle2
+    mock_profile2.display_name = "Test User 2"
+    mock_profile2.description = None  # Test None description
+    mock_profile2.avatar = None
+    mock_profile2.banner = None
+    mock_profile2.followers_count = 0
+    mock_profile2.follows_count = 0
+    mock_profile2.posts_count = 0
+    mock_profile2.created_at = "2023-02-01T00:00:00.000Z"
+    mock_profile2.indexed_at = None
+    
+    return {
+        'test_did1': test_did1,
+        'test_did2': test_did2,
+        'test_handle1': test_handle1,
+        'test_handle2': test_handle2,
+        'mock_profile1': mock_profile1,
+        'mock_profile2': mock_profile2
+    }
+
+
+class TestProfileList:
+
+    def test_profile_list_basic_operations(self, mock_profile_list_environment):
+        """Test basic ProfileList operations"""
+        env = mock_profile_list_environment
+        profile_list = ProfileList()
+        
+        # Test initial state
+        assert len(profile_list) == 0
+        assert str(profile_list) == "[]"
+        
+        # Test append
+        result = profile_list.append(env['test_did1'])
+        assert result is profile_list  # Should return self for chaining
+        assert len(profile_list) == 1
+        assert profile_list[0] == env['test_did1']
+        
+        # Test append multiple
+        profile_list.append(env['test_did2'])
+        assert len(profile_list) == 2
+        assert profile_list[1] == env['test_did2']
+        
+        # Test iteration
+        dids = list(profile_list)
+        assert dids == [env['test_did1'], env['test_did2']]
+
+    def test_profile_list_custom_delimiter(self):
+        """Test custom delimiter functionality"""
+        # Test class-level delimiter
+        original_delimiter = ProfileList.get_default_delimiter()
+        ProfileList.set_default_delimiter('|')
+        assert ProfileList.get_default_delimiter() == '|'
+        
+        # Test instance-level delimiter
+        profile_list = ProfileList(default_delimiter=',')
+        assert profile_list.default_delimiter == ','
+        
+        # Restore original delimiter
+        ProfileList.set_default_delimiter(original_delimiter)
+
+    def test_profile_item_basic_functionality(self, mock_profile_list_environment):
+        """Test ProfileList.Item basic functionality"""
+        env = mock_profile_list_environment
+        item = ProfileList.Item(env['mock_profile1'])
+        
+        # Test id
+        assert item.id() == env['test_did1']
+        
+        # Test text_only
+        assert item.text_only() == "This is a test user description"
+        
+        # Test with None description
+        item2 = ProfileList.Item(env['mock_profile2'])
+        assert item2.text_only() == ""
+
+    def test_profile_item_short_format(self, mock_profile_list_environment):
+        """Test ProfileList.Item short format"""
+        env = mock_profile_list_environment
+        item = ProfileList.Item(env['mock_profile1'])
+        
+        # Test default delimiter
+        short_output = item.short()
+        expected_parts = [
+            env['test_did1'],
+            env['test_handle1'],
+            "Test_User_1",  # summarize converts spaces to underscores
+            "This_is_a_test_user_description"  # summarize converts spaces to underscores
+        ]
+        assert short_output == " ".join(expected_parts)
+        
+        # Test custom delimiter
+        short_output_custom = item.short(delimiter="|")
+        assert short_output_custom == "|".join(expected_parts)
+
+    def test_profile_item_long_format(self, mock_profile_list_environment):
+        """Test ProfileList.Item long format"""
+        env = mock_profile_list_environment
+        item = ProfileList.Item(env['mock_profile1'])
+        long_output = item.long()
+        
+        expected_lines = [
+            "Created-At: 2023-01-01T00:00:00.000Z",
+            "DID: did:plc:test123",
+            "Display-Name: Test User 1",
+            "Handle: test1.bsky.social",
+            "",
+            "This is a test user description"
+        ]
+        assert long_output == "\n".join(expected_lines)
+
+    def test_profile_item_json_format(self, mock_profile_list_environment):
+        """Test ProfileList.Item JSON format"""
+        env = mock_profile_list_environment
+        item = ProfileList.Item(env['mock_profile1'])
+        
+        with patch('atproto_client.models.utils.get_model_as_json') as mock_json:
+            mock_json.return_value = '{"test": "json"}'
+            json_output = item.json()
+            assert json_output == '{"test": "json"}'
+            mock_json.assert_called_once_with(env['mock_profile1'])
+
+    def test_profile_item_simple_json_format(self, mock_profile_list_environment):
+        """Test ProfileList.Item simple JSON format"""
+        env = mock_profile_list_environment
+        item = ProfileList.Item(env['mock_profile1'])
+        simple_json_output = item.simple_json()
+        
+        # Parse the JSON to verify structure
+        parsed = json.loads(simple_json_output)
+        assert parsed["status"] == "ok"
+        assert "data" in parsed
+        
+        data = parsed["data"]
+        assert data["did"] == env['test_did1']
+        assert data["handle"] == env['test_handle1']
+        assert data["display_name"] == "Test User 1"
+        assert data["description"] == "This is a test user description"
+        assert data["followers_count"] == 100
+        assert data["follows_count"] == 50
+        assert data["posts_count"] == 25
+
+    def test_profile_item_simple_json_with_none_values(self, mock_profile_list_environment):
+        """Test ProfileList.Item simple JSON with None values"""
+        env = mock_profile_list_environment
+        item = ProfileList.Item(env['mock_profile2'])
+        simple_json_output = item.simple_json()
+        
+        parsed = json.loads(simple_json_output)
+        data = parsed["data"]
+        assert data["description"] == ""  # None should become empty string
+        assert data["banner"] is None
+        assert data["indexed_at"] is None
+
+    def test_profile_item_printable_formats(self, mock_profile_list_environment):
+        """Test ProfileList.Item printable method with different formats"""
+        env = mock_profile_list_environment
+        item = ProfileList.Item(env['mock_profile1'])
+        
+        # Test id format
+        assert item.printable('id') == env['test_did1']
+        
+        # Test long format
+        long_output = item.printable('long')
+        assert "Created-At: 2023-01-01T00:00:00.000Z" in long_output
+        
+        # Test text format
+        assert item.printable('text') == "This is a test user description"
+        
+        # Test json format
+        with patch('atproto_client.models.utils.get_model_as_json') as mock_json:
+            mock_json.return_value = '{"test": "json"}'
+            assert item.printable('json') == '{"test": "json"}'
+        
+        # Test simple_json format
+        simple_json_output = item.printable('simple_json')
+        parsed = json.loads(simple_json_output)
+        assert parsed["status"] == "ok"
+        
+        # Test default (short) format
+        short_output = item.printable('short')
+        assert env['test_did1'] in short_output
+        assert env['test_handle1'] in short_output
+
+    def test_profile_item_filename_generation(self, mock_profile_list_environment):
+        """Test ProfileList.Item filename generation"""
+        env = mock_profile_list_environment
+        item = ProfileList.Item(env['mock_profile1'])
+        filename = item.get_filename()
+        assert filename == "test1.bsky.social.txt"
+
+    def test_profile_list_update_with_mock_session(self, mock_profile_list_environment):
+        """Test ProfileList update method with mocked session"""
+        env = mock_profile_list_environment
+        profile_list = ProfileList()
+        profile_list.append(env['test_did1'])
+        profile_list.append(env['test_did2'])
+        
+        # Mock SskySession and client
+        mock_session = Mock()
+        mock_client = Mock()
+        mock_session.client.return_value = mock_client
+        
+        # Mock get_profiles response
+        mock_response = Mock()
+        mock_response.profiles = [env['mock_profile1'], env['mock_profile2']]
+        mock_client.get_profiles.return_value = mock_response
+        
+        with patch('ssky.profile_list.SskySession') as mock_session_class:
+            mock_session_class.return_value = mock_session
+            
+            # Test update
+            result = profile_list.update()
+            assert result is profile_list  # Should return self
+            assert profile_list.items is not None
+            assert len(profile_list.items) == 2
+            
+            # Verify get_profiles was called with correct DIDs
+            mock_client.get_profiles.assert_called_once_with([env['test_did1'], env['test_did2']])
+
+    def test_profile_list_update_large_list(self):
+        """Test ProfileList update with more than 25 items (pagination)"""
+        profile_list = ProfileList()
+        
+        # Add 30 DIDs to test pagination
+        test_dids = [f"did:plc:test{i:03d}" for i in range(30)]
+        for did in test_dids:
+            profile_list.append(did)
+        
+        # Mock session and client
+        mock_session = Mock()
+        mock_client = Mock()
+        mock_session.client.return_value = mock_client
+        
+        # Mock profiles for responses
+        mock_profiles_1 = [Mock() for _ in range(25)]
+        mock_profiles_2 = [Mock() for _ in range(5)]
+        
+        mock_response_1 = Mock()
+        mock_response_1.profiles = mock_profiles_1
+        mock_response_2 = Mock()
+        mock_response_2.profiles = mock_profiles_2
+        
+        mock_client.get_profiles.side_effect = [mock_response_1, mock_response_2]
+        
+        with patch('ssky.profile_list.SskySession') as mock_session_class:
+            mock_session_class.return_value = mock_session
+            
+            profile_list.update()
+            
+            # Should make 2 calls for pagination
+            assert mock_client.get_profiles.call_count == 2
+            
+            # Verify call arguments
+            call_args_list = mock_client.get_profiles.call_args_list
+            assert call_args_list[0][0][0] == test_dids[:25]  # First 25
+            assert call_args_list[1][0][0] == test_dids[25:]  # Last 5
+
+    def test_profile_list_print_console_output(self, mock_profile_list_environment):
+        """Test ProfileList print method for console output"""
+        env = mock_profile_list_environment
+        profile_list = ProfileList()
+        profile_list.items = [
+            ProfileList.Item(env['mock_profile1']),
+            ProfileList.Item(env['mock_profile2'])
+        ]
+        
+        # Test simple_json format (special case)
+        with patch('builtins.print') as mock_print:
+            profile_list.print('simple_json')
+            
+            # Should print a single JSON response with all profiles
+            mock_print.assert_called_once()
+            printed_content = mock_print.call_args[0][0]
+            parsed = json.loads(printed_content)
+            assert parsed["status"] == "ok"
+            assert len(parsed["data"]) == 2
+        
+        # Test other formats
+        with patch('builtins.print') as mock_print:
+            profile_list.print('short')
+            
+            # Should print each item individually
+            assert mock_print.call_count == 2
+
+    def test_profile_list_print_long_format_with_separator(self, mock_profile_list_environment):
+        """Test ProfileList print method with long format separator"""
+        env = mock_profile_list_environment
+        profile_list = ProfileList()
+        profile_list.items = [
+            ProfileList.Item(env['mock_profile1']),
+            ProfileList.Item(env['mock_profile2'])
+        ]
+        
+        with patch('builtins.print') as mock_print:
+            profile_list.print('long')
+            
+            # Should print: item1, separator, item2
+            assert mock_print.call_count == 3
+            # Check that separator was printed
+            separator_call = mock_print.call_args_list[1]
+            assert separator_call[0][0] == '----------------'
+
+    def test_profile_list_print_file_output(self, mock_profile_list_environment):
+        """Test ProfileList print method for file output"""
+        env = mock_profile_list_environment
+        profile_list = ProfileList()
+        profile_list.items = [
+            ProfileList.Item(env['mock_profile1']),
+            ProfileList.Item(env['mock_profile2'])
+        ]
+        
+        # Create temporary directory
+        with tempfile.TemporaryDirectory() as temp_dir:
+            profile_list.print('short', output=temp_dir)
+            
+            # Check that files were created
+            expected_files = [
+                "test1.bsky.social.txt",
+                "test2.bsky.social.txt"
+            ]
+            
+            for filename in expected_files:
+                filepath = os.path.join(temp_dir, filename)
+                assert os.path.exists(filepath)
+                
+                # Check file content
+                with open(filepath, 'r') as f:
+                    content = f.read().strip()
+                    if filename == "test1.bsky.social.txt":
+                        assert env['test_did1'] in content
+                        assert env['test_handle1'] in content
+                    else:
+                        assert env['test_did2'] in content
+                        assert env['test_handle2'] in content
+
+    def test_profile_list_print_file_output_with_custom_delimiter(self, mock_profile_list_environment):
+        """Test ProfileList print method for file output with custom delimiter"""
+        env = mock_profile_list_environment
+        profile_list = ProfileList()
+        profile_list.items = [ProfileList.Item(env['mock_profile1'])]
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            profile_list.print('short', output=temp_dir, delimiter='|')
+            
+            filepath = os.path.join(temp_dir, "test1.bsky.social.txt")
+            with open(filepath, 'r') as f:
+                content = f.read().strip()
+                # Should use custom delimiter
+                assert '|' in content
+                assert env['test_did1'] in content
+
+    def test_profile_list_edge_cases(self, mock_profile_list_environment):
+        """Test ProfileList edge cases"""
+        env = mock_profile_list_environment
+        # Test empty list
+        empty_list = ProfileList()
+        assert len(empty_list) == 0
+        
+        # Test update on empty list
+        with patch('ssky.profile_list.SskySession'):
+            result = empty_list.update()
+            assert result is empty_list
+            assert empty_list.items == []
+        
+        # Test multiple updates (should not duplicate items)
+        profile_list = ProfileList()
+        profile_list.append(env['test_did1'])
+        
+        mock_session = Mock()
+        mock_client = Mock()
+        mock_session.client.return_value = mock_client
+        mock_response = Mock()
+        mock_response.profiles = [env['mock_profile1']]
+        mock_client.get_profiles.return_value = mock_response
+        
+        with patch('ssky.profile_list.SskySession') as mock_session_class:
+            mock_session_class.return_value = mock_session
+            
+            # First update
+            profile_list.update()
+            first_items_count = len(profile_list.items)
+            
+            # Second update should not call API again
+            profile_list.update()
+            assert len(profile_list.items) == first_items_count
+            assert mock_client.get_profiles.call_count == 1  # Called only once 

--- a/tests/test_repost_unrepost.py
+++ b/tests/test_repost_unrepost.py
@@ -1,53 +1,212 @@
 import os
+import tempfile
+import pytest
+from unittest.mock import patch, Mock
+
 from ssky.post_data_list import PostDataList
 from ssky.repost import repost
 from ssky.unrepost import unrepost
-from tests.common import setup, teardown
+from ssky.ssky_session import SskySession
+from ssky.util import ErrorResult, disjoin_uri_cid
+from tests.common import create_mock_ssky_session, has_credentials
 
-def test_repost_by_uri():
-    setup()
-    result = repost(os.environ.get('SSKY_TEST_URI'))
-    teardown()
-    assert type(result) is PostDataList
+@pytest.fixture
+def mock_repost_environment():
+    """Setup test environment for repost/unrepost tests"""
+    if not has_credentials():
+        pytest.skip("No credentials available")
+    
+    # Create mock session for all repost/unrepost tests
+    mock_session, mock_client, mock_profile = create_mock_ssky_session()
+    
+    # Set up proper mock responses for repost/unrepost functionality
+    # Mock repost response
+    mock_repost_response = Mock()
+    mock_repost_response.uri = "at://test.user/app.bsky.feed.repost/test123"
+    mock_repost_response.cid = "repostcid123"
+    mock_client.repost.return_value = mock_repost_response
+    
+    # Mock unrepost response
+    mock_client.unrepost.return_value = True
+    
+    # Mock original post with repost viewer info for unrepost functionality
+    mock_viewer = Mock()
+    mock_viewer.repost = "at://test.user/app.bsky.feed.repost/test123"
+    
+    # Get actual URI and CID from environment for proper mock setup
+    uri_cid = os.environ.get('SSKY_TEST_URI_CID', 'at://test.user/app.bsky.feed.post/test123::testcid123')
+    actual_uri, actual_cid = disjoin_uri_cid(uri_cid)
+    
+    mock_original_post = Mock()
+    mock_original_post.uri = actual_uri
+    mock_original_post.cid = actual_cid
+    mock_original_post.viewer = mock_viewer
+    mock_original_post.__str__ = lambda: mock_original_post.uri
+    
+    # Mock posts response
+    mock_posts_response = Mock()
+    mock_posts_response.posts = [mock_original_post]
+    mock_client.get_posts.return_value = mock_posts_response
+    
+    return mock_session, mock_client, mock_profile
 
-def test_unrepost_by_uri():
-    setup(interval=5)
-    result = unrepost(os.environ.get('SSKY_TEST_URI'))
-    teardown()
-    assert type(result) is PostDataList
-
-def test_unrepost_by_not_reposted_uri():
-    setup(interval=5)
-    result = unrepost(os.environ.get('SSKY_TEST_URI'))
-    teardown()
-    assert result is None
-
-def test_repost_by_uri_cid():
-    setup()
-    result = repost(os.environ.get('SSKY_TEST_URI_CID'))
-    teardown()
-    assert type(result) is PostDataList
-
-def test_unrepost_by_uri_cid():
-    setup(interval=5)
-    result = unrepost(os.environ.get('SSKY_TEST_URI_CID'))
-    teardown()
-    assert type(result) is PostDataList
-
-def test_unrepost_by_not_reposted_uri_cid():
-    setup(interval=5)
-    result = unrepost(os.environ.get('SSKY_TEST_URI_CID'))
-    teardown()
-    assert result is None
-
-def test_repost_by_invalid_uri():
-    setup()
-    result = repost(os.environ.get('SSKY_TEST_INVALID_URI'))
-    teardown()
-    assert result is None
-
-def test_unrepost_by_invalid_uri():
-    setup()
-    result = unrepost(os.environ.get('SSKY_TEST_INVALID_URI'))
-    teardown()
-    assert result is None
+class TestRepostUnrepostSequential:
+    """Sequential repost/unrepost tests using mocked SskySession
+    
+    Strategy: 1 real repost/unrepost cycle + mocked tests for other scenarios
+    This reduces API calls and avoids rate limits.
+    """
+    
+    def test_01_real_repost_unrepost_by_uri(self):
+        """Real API test - repost and unrepost by URI (only real API test in this file)"""
+        # Skip if no credentials available
+        if not has_credentials():
+            pytest.skip("SSKY_USER environment variable not set")
+        
+        # This test uses real API calls - no mocking
+        try:
+            uri = os.environ.get('SSKY_TEST_URI', 'at://test.user/app.bsky.feed.post/test123')
+            
+            # Repost
+            repost_result = repost(uri)
+            assert isinstance(repost_result, PostDataList), "Repost should return PostDataList"
+            
+            # Wait a bit before unreposting
+            import time
+            time.sleep(5)
+            
+            # Unrepost
+            unrepost_result = unrepost(uri)
+            assert isinstance(unrepost_result, PostDataList), "Unrepost should return PostDataList"
+            
+        finally:
+            SskySession.clear()
+    
+    def test_02_repost_by_uri_cid_with_mock(self, mock_repost_environment):
+        """Test repost by URI+CID using mocked session"""
+        mock_session, mock_client, mock_profile = mock_repost_environment
+        
+        with patch('ssky.repost.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            uri_cid = os.environ.get('SSKY_TEST_URI_CID', 'at://test.user/app.bsky.feed.post/test123::testcid123')
+            result = repost(uri_cid)
+            
+            assert isinstance(result, PostDataList), "Repost should return PostDataList"
+    
+    def test_03_unrepost_by_uri_cid_with_mock(self, mock_repost_environment):
+        """Test unrepost by URI+CID using mocked session"""
+        mock_session, mock_client, mock_profile = mock_repost_environment
+        
+        with patch('ssky.unrepost.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            uri_cid = os.environ.get('SSKY_TEST_URI_CID', 'at://test.user/app.bsky.feed.post/test123::testcid123')
+            result = unrepost(uri_cid)
+            
+            assert isinstance(result, PostDataList), "Unrepost should return PostDataList"
+    
+    def test_04_unrepost_not_reposted_uri(self, mock_repost_environment):
+        """Test unrepost URI that was not reposted"""
+        mock_session, mock_client, mock_profile = mock_repost_environment
+        
+        # Mock post without repost viewer info (not reposted)
+        mock_original_post = Mock()
+        mock_original_post.uri = "at://test.user/app.bsky.feed.post/test123"
+        mock_original_post.cid = "testcid123"
+        mock_original_post.viewer = Mock()
+        mock_original_post.viewer.repost = None  # Not reposted
+        mock_original_post.__str__ = lambda: mock_original_post.uri
+        
+        # Override the get_posts response
+        mock_posts_response = Mock()
+        mock_posts_response.posts = [mock_original_post]
+        mock_client.get_posts.return_value = mock_posts_response
+        
+        with patch('ssky.unrepost.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            uri = os.environ.get('SSKY_TEST_URI', 'at://test.user/app.bsky.feed.post/test123')
+            result = unrepost(uri)
+            
+            assert isinstance(result, ErrorResult), "Unrepost should return ErrorResult when not reposted"
+    
+    def test_05_repost_invalid_uri(self, mock_repost_environment):
+        """Test repost with invalid URI"""
+        mock_session, mock_client, mock_profile = mock_repost_environment
+        
+        # Mock repost to raise exception for invalid URI
+        import atproto_client
+        mock_client.repost.side_effect = atproto_client.exceptions.AtProtocolError("Post not found")
+        
+        with patch('ssky.repost.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            invalid_uri = os.environ.get('SSKY_TEST_INVALID_URI', 'at://invalid/uri')
+            result = repost(invalid_uri)
+            
+            assert isinstance(result, ErrorResult), "Repost should return ErrorResult for invalid URI"
+    
+    def test_06_unrepost_invalid_uri(self, mock_repost_environment):
+        """Test unrepost with invalid URI"""
+        mock_session, mock_client, mock_profile = mock_repost_environment
+        
+        # Mock get_posts to raise exception for invalid URI
+        import atproto_client
+        mock_client.get_posts.side_effect = atproto_client.exceptions.AtProtocolError("Post not found")
+        
+        with patch('ssky.unrepost.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            invalid_uri = os.environ.get('SSKY_TEST_INVALID_URI', 'at://invalid/uri')
+            result = unrepost(invalid_uri)
+            
+            assert isinstance(result, ErrorResult), "Unrepost should return ErrorResult for invalid URI"
+    
+    def test_07_repost_unrepost_error_scenarios(self):
+        """Test error handling scenarios"""
+        # Test 1: No session available for repost
+        with patch('ssky.repost.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = None
+            
+            result = repost("at://test.user/app.bsky.feed.post/test123")
+            assert isinstance(result, ErrorResult), "Repost should return ErrorResult when no session available"
+            assert result.http_code == 401, "Should return 401 error code"
+        
+        # Test 2: No session available for unrepost
+        with patch('ssky.unrepost.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = None
+            
+            result = unrepost("at://test.user/app.bsky.feed.post/test123")
+            assert isinstance(result, ErrorResult), "Unrepost should return ErrorResult when no session available"
+            assert result.http_code == 401, "Should return 401 error code"
+        
+        # Test 3: Empty URI for repost
+        result = repost("")
+        assert isinstance(result, ErrorResult), "Repost should return ErrorResult with empty URI"
+        
+        # Test 4: Empty URI for unrepost
+        result = unrepost("")
+        assert isinstance(result, ErrorResult), "Unrepost should return ErrorResult with empty URI"
+    
+    def test_08_repost_unrepost_with_json_format(self, mock_repost_environment):
+        """Test repost/unrepost with JSON format output"""
+        mock_session, mock_client, mock_profile = mock_repost_environment
+        
+        # Test repost with JSON format
+        with patch('ssky.repost.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            uri = os.environ.get('SSKY_TEST_URI', 'at://test.user/app.bsky.feed.post/test123')
+            result = repost(uri, format='json')
+            
+            assert isinstance(result, PostDataList), "Repost should return PostDataList with JSON format"
+        
+        # Test unrepost with JSON format
+        with patch('ssky.unrepost.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            uri = os.environ.get('SSKY_TEST_URI', 'at://test.user/app.bsky.feed.post/test123')
+            result = unrepost(uri, format='json')
+            
+            assert isinstance(result, PostDataList), "Unrepost should return PostDataList with JSON format"

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,58 +1,208 @@
 import os
+import tempfile
+import pytest
+from unittest.mock import patch, Mock
+
 from ssky.post_data_list import PostDataList
 from ssky.search import search
-from tests.common import setup, teardown
+from ssky.ssky_session import SskySession
+from ssky.util import ErrorResult
+from tests.common import create_mock_ssky_session, has_credentials
 
-def test_search_q():
-    setup()
-    result = search(os.environ.get('SSKY_TEST_Q'))
-    teardown()
-    assert type(result) is PostDataList
+@pytest.fixture
+def mock_search_environment():
+    """Setup test environment for search tests"""
+    if not has_credentials():
+        pytest.skip("No credentials available")
+    
+    # Create mock session for all search tests
+    mock_session, mock_client, mock_profile = create_mock_ssky_session()
+    
+    # Set up proper mock responses for search functionality
+    # Mock search post
+    mock_post = Mock()
+    mock_post.uri = "at://test.user/app.bsky.feed.post/test123"
+    mock_post.cid = "testcid123"
+    mock_post.__str__ = lambda: mock_post.uri
+    
+    # Add required attributes for PostDataList
+    mock_author = Mock()
+    mock_author.did = "did:plc:test123"
+    mock_author.handle = "test.bsky.social"
+    mock_author.display_name = "Test User"
+    mock_author.avatar = "https://example.com/avatar.jpg"
+    mock_post.author = mock_author
+    
+    mock_record = Mock()
+    mock_record.text = "Test post content"
+    mock_record.created_at = "2023-01-01T00:00:00.000Z"
+    mock_record.facets = None
+    mock_post.record = mock_record
+    
+    mock_post.indexed_at = "2023-01-01T01:00:00.000Z"
+    mock_post.reply_count = 0
+    mock_post.repost_count = 0
+    mock_post.like_count = 0
+    mock_post.viewer = None
+    
+    # Set up search response
+    mock_search_response = Mock()
+    mock_search_response.posts = [mock_post]
+    mock_client.app.bsky.feed.search_posts.return_value = mock_search_response
+    
+    return mock_session, mock_client, mock_profile
 
-def test_search_q_with_limit():
-    setup()
-    result = search(os.environ.get('SSKY_TEST_Q'), limit=int(os.environ.get('SSKY_TEST_LIMIT')))
-    teardown()
-    assert type(result) is PostDataList and len(result) == int(os.environ.get('SSKY_TEST_LIMIT'))
-
-def test_search_q_with_no_results():
-    setup()
-    result = search(os.environ.get('SSKY_TEST_Q_WITH_NO_RESULTS'))
-    teardown()
-    assert type(result) is PostDataList
-
-def test_search_with_actor_handle():
-    setup()
-    result = search(os.environ.get('SSKY_TEST_Q'), actor=os.environ.get('SSKY_TEST_USER_HANDLE'))
-    teardown()
-    assert type(result) is PostDataList
-
-def test_search_with_actor_did():
-    setup()
-    result = search(os.environ.get('SSKY_TEST_Q'), actor=os.environ.get('SSKY_TEST_USER_DID'))
-    teardown()
-    assert type(result) is PostDataList
-
-def test_search_with_period():
-    setup()
-    result = search(os.environ.get('SSKY_TEST_Q'), since=os.environ.get('SSKY_TEST_SINCE'), until=os.environ.get('SSKY_TEST_UNTIL'))
-    teardown()
-    assert type(result) is PostDataList
-
-def test_search_with_period_only_beginning():
-    setup()
-    result = search(os.environ.get('SSKY_TEST_Q'), since=os.environ.get('SSKY_TEST_SINCE'))
-    teardown()
-    assert type(result) is PostDataList
-
-def test_search_with_period_only_end():
-    setup()
-    result = search(os.environ.get('SSKY_TEST_Q'), until=os.environ.get('SSKY_TEST_SINCE'))
-    teardown()
-    assert type(result) is PostDataList
-
-def test_search_with_invalid_period():
-    setup()
-    result = search(os.environ.get('SSKY_TEST_Q'), since=os.environ.get('SSKY_TEST_INVALID_SINCE'), until=os.environ.get('SSKY_TEST_INVALID_UNTIL'))
-    teardown()
-    assert result is None
+class TestSearchSequential:
+    """Sequential search tests using mocked SskySession
+    
+    Strategy: 1 real search + mocked tests for other scenarios
+    This reduces API calls and avoids rate limits.
+    """
+    
+    def test_01_real_search_basic(self):
+        """Real API test - basic search functionality (only real API test in this file)"""
+        # Skip if no credentials available
+        if not has_credentials():
+            pytest.skip("SSKY_USER environment variable not set")
+        
+        # This test uses real API calls - no mocking
+        try:
+            query = os.environ.get('SSKY_TEST_Q', 'test')
+            result = search(query)
+            assert isinstance(result, PostDataList), "Search should return PostDataList"
+        finally:
+            SskySession.clear()
+    
+    def test_02_search_with_limit(self, mock_search_environment):
+        """Test search with limit using mocked session"""
+        mock_session, mock_client, mock_profile = mock_search_environment
+        
+        # Mock search response with limited results
+        limit = int(os.environ.get('SSKY_TEST_LIMIT', '1'))  # Default to 1 for predictable testing
+        mock_posts = []
+        
+        for i in range(limit):
+            mock_post = Mock()
+            mock_post.uri = f"at://test.user/app.bsky.feed.post/test{i}"
+            mock_post.cid = f"testcid{i}"
+            mock_post.__str__ = lambda: mock_post.uri
+            
+            # Add required attributes for PostDataList
+            mock_author = Mock()
+            mock_author.did = f"did:plc:test{i}"
+            mock_author.handle = f"test{i}.bsky.social"
+            mock_author.display_name = f"Test User {i}"
+            mock_author.avatar = "https://example.com/avatar.jpg"
+            mock_post.author = mock_author
+            
+            mock_record = Mock()
+            mock_record.text = f"Test post {i}"
+            mock_record.created_at = "2023-01-01T00:00:00.000Z"
+            mock_record.facets = None
+            mock_post.record = mock_record
+            
+            mock_post.indexed_at = "2023-01-01T01:00:00.000Z"
+            mock_post.reply_count = 0
+            mock_post.repost_count = 0
+            mock_post.like_count = 0
+            mock_post.viewer = None
+            
+            mock_posts.append(mock_post)
+        
+        mock_search_response = Mock()
+        mock_search_response.posts = mock_posts
+        mock_client.app.bsky.feed.search_posts.return_value = mock_search_response
+        
+        with patch('ssky.search.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            query = os.environ.get('SSKY_TEST_Q', 'test')
+            limit = int(os.environ.get('SSKY_TEST_LIMIT', '1'))  # Use same default as above
+            result = search(query, limit=limit)
+            
+            assert isinstance(result, PostDataList), "Search should return PostDataList"
+            assert len(result) == limit, f"Should return exactly {limit} results"
+    
+    def test_03_search_with_no_results(self, mock_search_environment):
+        """Test search with query that returns no results"""
+        mock_session, mock_client, mock_profile = mock_search_environment
+        
+        # Mock search response with no results
+        mock_search_response = Mock()
+        mock_search_response.posts = []
+        mock_client.app.bsky.feed.search_posts.return_value = mock_search_response
+        
+        with patch('ssky.search.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            query = os.environ.get('SSKY_TEST_Q_WITH_NO_RESULTS', 'nonexistentquerythatreturnsnothing123')
+            result = search(query)
+            
+            assert isinstance(result, PostDataList), "Search should return PostDataList even with no results"
+            assert len(result) == 0, "Should return empty results"
+    
+    def test_04_search_with_actor_handle(self, mock_search_environment):
+        """Test search with actor handle filter"""
+        mock_session, mock_client, mock_profile = mock_search_environment
+        
+        with patch('ssky.search.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            query = os.environ.get('SSKY_TEST_Q', 'test')
+            actor = os.environ.get('SSKY_TEST_USER_HANDLE', 'test.bsky.social')
+            result = search(query, actor=actor)
+            
+            assert isinstance(result, PostDataList), "Search should return PostDataList"
+    
+    def test_05_search_with_actor_did(self, mock_search_environment):
+        """Test search with actor DID filter"""
+        mock_session, mock_client, mock_profile = mock_search_environment
+        
+        with patch('ssky.search.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            query = os.environ.get('SSKY_TEST_Q', 'test')
+            actor = os.environ.get('SSKY_TEST_DID', 'did:plc:test123')
+            result = search(query, actor=actor)
+            
+            assert isinstance(result, PostDataList), "Search should return PostDataList"
+    
+    def test_06_search_with_time_period(self, mock_search_environment):
+        """Test search with time period filters"""
+        mock_session, mock_client, mock_profile = mock_search_environment
+        
+        with patch('ssky.search.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            query = os.environ.get('SSKY_TEST_Q', 'test')
+            since = os.environ.get('SSKY_TEST_SINCE', '2023-01-01T00:00:00Z')
+            until = os.environ.get('SSKY_TEST_UNTIL', '2023-12-31T23:59:59Z')
+            result = search(query, since=since, until=until)
+            
+            assert isinstance(result, PostDataList), "Search should return PostDataList"
+    
+    def test_07_search_error_scenarios(self):
+        """Test error handling scenarios"""
+        # Test: No session available
+        with patch('ssky.search.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = None
+            
+            result = search("test")
+            assert isinstance(result, ErrorResult), "Search should return ErrorResult when no session available"
+            assert result.http_code == 401, "Search should return 401 error code"
+        
+        # Test: Empty query
+        result = search("")
+        assert isinstance(result, ErrorResult), "Search should return ErrorResult with empty query"
+    
+    def test_08_search_with_json_format(self, mock_search_environment):
+        """Test search with JSON format output"""
+        mock_session, mock_client, mock_profile = mock_search_environment
+        
+        with patch('ssky.search.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            query = os.environ.get('SSKY_TEST_Q', 'test')
+            result = search(query, format='json')
+            
+            assert isinstance(result, PostDataList), "Search should return PostDataList with JSON format"

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,22 +1,125 @@
 import os
+import tempfile
+import pytest
+from unittest.mock import patch, Mock
+
 from ssky.profile_list import ProfileList
 from ssky.user import user
-from tests.common import setup, teardown
+from ssky.ssky_session import SskySession
+from ssky.util import ErrorResult
+from tests.common import create_mock_ssky_session, has_credentials
 
-def test_user_q():
-    setup()
-    result = user(os.environ.get('SSKY_TEST_Q'))
-    teardown()
-    assert type(result) is ProfileList
+@pytest.fixture
+def mock_user_environment():
+    """Setup test environment for user tests"""
+    if not has_credentials():
+        pytest.skip("No credentials available")
+    
+    # Create mock session for all user tests
+    mock_session, mock_client, mock_profile = create_mock_ssky_session()
+    
+    # Set up proper mock responses for user search functionality
+    # Mock user/actor for search response
+    mock_actor = Mock()
+    mock_actor.did = "did:plc:test123"
+    mock_actor.handle = "test.bsky.social"
+    mock_actor.display_name = "Test User"
+    mock_actor.avatar = "https://example.com/avatar.jpg"
+    
+    # Set up user search response
+    mock_search_response = Mock()
+    mock_search_response.actors = [mock_actor]
+    mock_client.app.bsky.actor.search_actors.return_value = mock_search_response
+    
+    return mock_session, mock_client, mock_profile
 
-def test_user_q_with_limit():
-    setup()
-    result = user(os.environ.get('SSKY_TEST_Q'), limit=int(os.environ.get('SSKY_TEST_LIMIT')))
-    teardown()
-    assert type(result) is ProfileList and len(result) == int(os.environ.get('SSKY_TEST_LIMIT'))
-
-def test_user_q_with_no_results():
-    setup()
-    result = user(os.environ.get('SSKY_TEST_Q_WITH_NO_RESULTS'))
-    teardown()
-    assert type(result) is ProfileList
+class TestUserSequential:
+    """Sequential user search tests using mocked SskySession
+    
+    Strategy: 1 real user search + mocked tests for other scenarios
+    This reduces API calls and avoids rate limits.
+    """
+    
+    def test_01_real_user_search(self):
+        """Real API test - basic user search functionality (only real API test in this file)"""
+        # Skip if no credentials available
+        if not has_credentials():
+            pytest.skip("SSKY_USER environment variable not set")
+        
+        # This test uses real API calls - no mocking
+        try:
+            query = os.environ.get('SSKY_TEST_Q', 'test')
+            result = user(query)
+            assert isinstance(result, ProfileList), "User search should return ProfileList"
+        finally:
+            SskySession.clear()
+    
+    def test_02_user_search_with_limit(self, mock_user_environment):
+        """Test user search with limit using mocked session"""
+        mock_session, mock_client, mock_profile = mock_user_environment
+        
+        # Mock user search response with limited results
+        limit = int(os.environ.get('SSKY_TEST_LIMIT', '3'))
+        mock_actors = []
+        for i in range(limit):
+            mock_actor = Mock()
+            mock_actor.did = f"did:plc:test{i}"
+            mock_actor.handle = f"test{i}.bsky.social"
+            mock_actors.append(mock_actor)
+        
+        mock_search_response = Mock()
+        mock_search_response.actors = mock_actors
+        mock_client.app.bsky.actor.search_actors.return_value = mock_search_response
+        
+        with patch('ssky.user.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            query = os.environ.get('SSKY_TEST_Q', 'test')
+            result = user(query, limit=limit)
+            
+            assert isinstance(result, ProfileList), "User search should return ProfileList"
+            assert len(result) == limit, f"Should return exactly {limit} results"
+    
+    def test_03_user_search_with_no_results(self, mock_user_environment):
+        """Test user search with query that returns no results"""
+        mock_session, mock_client, mock_profile = mock_user_environment
+        
+        # Mock user search response with no results
+        mock_search_response = Mock()
+        mock_search_response.actors = []
+        mock_client.app.bsky.actor.search_actors.return_value = mock_search_response
+        
+        with patch('ssky.user.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            query = os.environ.get('SSKY_TEST_Q_WITH_NO_RESULTS', 'nonexistentuserthatreturnsnothing123')
+            result = user(query)
+            
+            assert isinstance(result, ProfileList), "User search should return ProfileList even with no results"
+            assert len(result) == 0, "Should return empty results"
+    
+    def test_04_user_search_error_scenarios(self):
+        """Test error handling scenarios"""
+        # Test 1: No session available
+        with patch('ssky.user.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = None
+            
+            result = user("test query")
+            assert isinstance(result, ErrorResult), "User search should return ErrorResult when no session available"
+            assert result.http_code == 401, "Should return 401 error code"
+        
+        # Test 2: Empty query
+        result = user("")
+        assert isinstance(result, ErrorResult), "User search should return ErrorResult with empty query"
+    
+    def test_05_user_search_with_json_format(self, mock_user_environment):
+        """Test user search with JSON format output"""
+        mock_session, mock_client, mock_profile = mock_user_environment
+        
+        with patch('ssky.user.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = mock_client
+            
+            query = os.environ.get('SSKY_TEST_Q', 'test')
+            result = user(query, format='json')
+            
+            assert isinstance(result, ProfileList), "User search should return ProfileList with JSON format"


### PR DESCRIPTION
## Summary

This PR implements consistent JSON output format with proper error handling and HTTP status codes for `--json` and `--simple-json` flags across all CLI commands and MCP server functionality.

Fixes #31

## Key Changes

### 🔧 JSON Response Structure
- Implemented unified JSON response format with `status`, `http_code`, `message`, `timestamp`, and `data` fields
- Added utility functions in `src/ssky/util.py` for consistent response creation
- Removed redundant `success` field, using only `status: "ok"/"error"`

### 🚨 Error Handling
- All CLI commands now return JSON errors when `--json` or `--simple-json` flags are used
- HTTP status codes are properly extracted from AtProtocol exceptions and included in responses
- MCP server functions consistently return JSON error responses instead of raising exceptions

### 📁 Directory Structure Refactoring
- Moved MCP server from `mcp/ssky_server.py` to `src/ssky_mcp/server.py`
- Created proper package structure with `src/ssky_mcp/__init__.py`
- Updated Docker configurations and pyproject.toml accordingly
- Added `ssky-mcp-server` script entry point

### 🐛 Bug Fixes
- Fixed double-wrapping issue in MCP server responses
- Consolidated duplicate logic in `PostDataList` and `ProfileList` print methods
- Improved encapsulation by adding `get_simple_data()` methods to item classes
- Removed redundant imports and cleaned up code structure

### 📦 Version Update
- Bumped version from 0.1.3 to 0.2.0 due to breaking changes in JSON response format

## Testing

- ✅ All MCP tests pass (`test_mcp_quick.sh` and `test_mcp_full.sh`)
- ✅ JSON responses are properly formatted without double-wrapping
- ✅ Error handling works consistently across all commands
- ✅ Docker builds successfully with new structure

## Breaking Changes

⚠️ **JSON Response Format Changed**: The JSON output structure has been updated for consistency. Applications relying on the previous format will need to be updated.

**Before:**
```json
{"data": [...]}
```

**After:**
```json
{
  "status": "ok",
  "http_code": 200,
  "message": "Success",
  "timestamp": "2025-01-16T...",
  "data": [...]
}
```