### PR TITLE
fix: restore stdin reading functionality for post command (#41)

### DIFF
--- a/src/ssky/main.py
+++ b/src/ssky/main.py
@@ -90,6 +90,12 @@ def parse():
 
 def execute(subcommand, args) -> bool:
     try:
+        if subcommand == 'post' and hasattr(args, 'message') and args.message is None:
+            if not sys.stdin.isatty():
+                stdin_content = sys.stdin.read().strip()
+                if stdin_content:
+                    args.message = stdin_content
+            
         module = import_module(f'.{subcommand}', f'{__package__}')
         func = getattr(module, f'{subcommand}')
         result = func(**vars(args))


### PR DESCRIPTION
## Overview

This PR restores the stdin reading functionality for the `ssky post` command that was previously removed during refactoring.

## Changes

- Modified `src/ssky/main.py` `execute` function to detect when post command is called without a message argument
- Added pipe detection using `sys.stdin.isatty()`
- Implemented stdin content reading with proper whitespace handling
- Set processed stdin content as the message argument

## Testing

✅ `echo "Hello from stdin!" | ssky post --dry` - Basic stdin input  
✅ `printf "Message with #hashtag and @mention" | ssky post --dry` - Hashtags and mentions  
✅ Multi-line input handling  
✅ No regression in existing functionality  

## Fixes

Closes #41

## Implementation Details

The implementation is minimal and focused:
- Only reads from stdin when `message` argument is `None`
- Uses `sys.stdin.isatty()` to detect pipe input
- Strips whitespace and validates content before using
- Maintains backward compatibility