### PR TITLE
chore: bump atproto to ^0.0.65 and version to 0.3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ python = ">=3.12,<3.14"
 beautifulsoup4 = "^4.12.3"
 python-dotenv = "^1.0.1"
 requests = "^2.32.3"
-atproto = "^0.0.60"
+atproto = "^0.0.65"
 pytest = "^8.3.4"
 fastmcp = "^2.10.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ssky"
-version = "0.2.9"
+version = "0.3.0"
 description = "Simple bluesky client"
 authors = ["SimpleSkyClient Project <simpleskypclient@gmail.com>"]
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump `atproto` from `^0.0.60` to `^0.0.65` to silence the `UnsupportedFieldAttributeWarning` introduced by pydantic 2.12. atproto 0.0.65 removes the unsupported `Field(default=None, ...)` from `Annotated` metadata in generated models.
- Bump project version from 0.2.9 to 0.3.0.

## Background
pydantic 2.12 (released Oct 2025) added a new `UnsupportedFieldAttributeWarning` that triggers on every `ssky` invocation against the model definitions in atproto 0.0.60. Upstream atproto already addressed this in 0.0.65 by removing the redundant `default=None` argument inside `te.Annotated[Union[...], Field(default=None, discriminator='py_type')]`.

## Test plan
- [x] `poetry lock && poetry install` resolves cleanly
- [x] `poetry run ssky get -N 1` runs without the pydantic warning
- [ ] CI passes