### PR TITLE
Support Python 3.14 and modernize packaging

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
 {
 	"name": "Python 3",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:2-3.12-bullseye",
+	"image": "mcr.microsoft.com/devcontainers/python:3-3.14-bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
 		"ghcr.io/devcontainers/features/github-cli:1": {},

--- a/README.md
+++ b/README.md
@@ -275,7 +275,7 @@ For development using VS Code Dev Containers:
 2. The dev container automatically:
    - Loads environment variables from `.env.local`
    - Installs Claude Code extension
-   - Sets up Python 3.12 environment with Docker support
+   - Sets up Python 3.14 environment with Docker support
 
 ## 🧪 Testing
 

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.14-slim
 
 # Update system and install required packages
 RUN apt-get update && apt-get install -y \

--- a/mcp/Dockerfile.dev
+++ b/mcp/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.14-slim
 
 # Update system and install required packages
 RUN apt-get update && apt-get install -y \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,13 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = ">=3.12,<3.14"
+python = ">=3.12,<3.15"
 beautifulsoup4 = "^4.12.3"
 python-dotenv = "^1.0.1"
 requests = "^2.32.3"
-atproto = "^0.0.65"
+atproto = "^0.0.68"
 pytest = "^8.3.4"
-fastmcp = "^2.10.0"
+fastmcp = "^2.14.0"
 
 [tool.poetry.scripts]
 ssky = "ssky.main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 description = "Simple bluesky client"
 authors = ["SimpleSkyClient Project <simpleskypclient@gmail.com>"]
 readme = "README.md"
-license = "LICENSE"
+license = "MIT"
 homepage = "https://github.com/simpleskyclient/ssky"
 repository = "https://github.com/simpleskyclient/ssky"
 keywords = ["bluesky", "client"]
@@ -16,11 +16,13 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.12,<3.15"
 beautifulsoup4 = "^4.12.3"
-python-dotenv = "^1.0.1"
 requests = "^2.32.3"
 atproto = "^0.0.68"
-pytest = "^8.3.4"
 fastmcp = "^2.14.0"
+
+[tool.poetry.group.dev.dependencies]
+pytest = "^8.3.4"
+python-dotenv = "^1.0.1"
 
 [tool.poetry.scripts]
 ssky = "ssky.main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,33 +1,39 @@
-[tool.poetry]
+[project]
 name = "ssky"
 version = "0.3.0"
 description = "Simple bluesky client"
-authors = ["SimpleSkyClient Project <simpleskypclient@gmail.com>"]
+authors = [
+    {name = "SimpleSkyClient Project", email = "simpleskypclient@gmail.com"}
+]
 readme = "README.md"
 license = "MIT"
+keywords = ["bluesky", "client"]
+requires-python = ">=3.12,<3.15"
+dependencies = [
+    "beautifulsoup4 (>=4.12.3,<5.0.0)",
+    "requests (>=2.32.3,<3.0.0)",
+    "atproto (>=0.0.68,<0.0.69)",
+    "fastmcp (>=2.14.0,<3.0.0)",
+]
+
+[project.urls]
 homepage = "https://github.com/simpleskyclient/ssky"
 repository = "https://github.com/simpleskyclient/ssky"
-keywords = ["bluesky", "client"]
+
+[project.scripts]
+ssky = "ssky.main:main"
+ssky-mcp-server = "ssky_mcp.server:main"
+
+[tool.poetry]
 packages = [
     {include = "ssky", from = "src"},
     {include = "ssky_mcp", from = "src"}
 ]
 
-[tool.poetry.dependencies]
-python = ">=3.12,<3.15"
-beautifulsoup4 = "^4.12.3"
-requests = "^2.32.3"
-atproto = "^0.0.68"
-fastmcp = "^2.14.0"
-
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.3.4"
 python-dotenv = "^1.0.1"
 
-[tool.poetry.scripts]
-ssky = "ssky.main:main"
-ssky-mcp-server = "ssky_mcp.server:main"
-
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=2.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
Add Python 3.14 support and modernize packaging metadata.

The `python = ">=3.12,<3.14"` cap was a leftover from an older atproto; atproto already declares `requires-python = "<3.15,>=3.9"`. This relaxes the constraint and bumps dependencies to versions that ship cp314 wheels.

## Changes
- **Python 3.14**: `requires-python` `<3.14` -> `<3.15`; `atproto` `^0.0.65` -> `^0.0.68`; `fastmcp` `^2.10.0` -> `^2.14.0`.
- **Docker / devcontainer**: base images `python:3.12-*` -> `python:3.14-*` (`mcp/Dockerfile`, `mcp/Dockerfile.dev`, `.devcontainer/devcontainer.json`), README note updated.
- **Packaging hygiene**: fix `license` (`"LICENSE"` filename -> SPDX `"MIT"`); move test-only `pytest` and `python-dotenv` out of runtime deps to a dev group (they were unused in `src/`).
- **PEP 621**: migrate `[tool.poetry.*]` metadata to the standard `[project]` table (`poetry check` is now clean; previously 11 deprecation warnings).

## Why the dependency bumps were required
- **cp314 wheels**: `libipld`, `pydantic-core`, and `cffi` only ship Python 3.14 wheels at newer versions, pulled in transitively via the `atproto`/`pydantic` bumps.
- **atproto 0.0.68**: adds the `app.bsky.embed.gallery` model. Without it, real-API timeline fetches fail with `union_tag_invalid` now that Bluesky serves gallery embeds.
- **fastmcp 2.14**: `pydantic` 2.13 (required by the cp314 `pydantic-core`) makes `default` + `default_factory` a hard error, which crashes `import fastmcp` on 2.10.x regardless of Python version. 2.14 is compatible.

## Verification
- Python 3.14.6: full import smoke test (atproto / libipld / pydantic-core / cffi / cryptography / websockets / fastmcp / ssky / ssky_mcp) OK
- Python 3.14.6 test suite: **138 passed, 1 skipped**
- Python 3.12.9 test suite: **138 passed, 1 skipped**
- MCP Docker build on `python:3.14-slim` + healthcheck (ssky / FastMCP) OK
- MCP server JSON-RPC `initialize` + `tools/list` in the 3.14 container -> 10 tools
- `poetry check` -> "All set!"; `poetry build` wheel metadata verified (`License: MIT`, `Requires-Python: >=3.12,<3.15`, runtime `Requires-Dist` excludes pytest/dotenv, both console scripts and packages present)

## Notes
- `poetry.lock` is gitignored in this repo, so it is not part of this PR.
