### PR TITLE
Release v0.4.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ssky"
-version = "0.3.0"
+version = "0.4.0"
 description = "Simple bluesky client"
 authors = [
     {name = "SimpleSkyClient Project", email = "simpleskypclient@gmail.com"}


### PR DESCRIPTION
## Summary
Release v0.4.0.

Bumps the package version `0.3.0` -> `0.4.0` ahead of tagging and publishing.

## Highlights since v0.3.0
- **Python 3.14 support** (`requires-python` now `>=3.12,<3.15`); `atproto` -> `^0.0.68`, `fastmcp` -> `^2.14.0`.
- **Docker / devcontainer** base images moved to `python:3.14-*`.
- **Packaging modernization**: SPDX `license = "MIT"`, test-only deps moved to a dev group, and migration of metadata to the PEP 621 `[project]` table (`poetry check` is clean).

## Test plan
- [x] `poetry check` -> "All set!"
- [x] `poetry build` produces `ssky-0.4.0` sdist + wheel
- [x] `ssky --version` reports `0.4.0`
