### PR TITLE
ci: restore release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,117 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: simpleskyclient/ssky-mcp
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      id-token: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.12'
+
+    - name: Install Poetry
+      uses: snok/install-poetry@v1
+      with:
+        version: latest
+        virtualenvs-create: true
+        virtualenvs-in-project: true
+
+    - name: Build Python package
+      run: |
+        poetry build
+
+    - name: Publish to PyPI
+      env:
+        POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_API_TOKEN }}
+      run: |
+        poetry publish
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=raw,value=latest
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        file: ./mcp/Dockerfile
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+
+    - name: Test Docker image
+      run: |
+        # Basic health check
+        docker run --rm ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest /app/healthcheck.sh
+
+    - name: Generate release notes
+      id: release_notes
+      run: |
+        # Extract version from tag
+        VERSION=${GITHUB_REF#refs/tags/v}
+        echo "version=$VERSION" >> $GITHUB_OUTPUT
+        
+        # Generate basic release notes template
+        cat > release_notes.md << EOF
+        ## Release v$VERSION
+        
+        This release includes various improvements and updates to the ssky project.
+        
+        ### Installation
+        \`\`\`bash
+        pip install ssky==$VERSION
+        \`\`\`
+        
+        ### Docker
+        \`\`\`bash
+        docker pull ghcr.io/simpleskyclient/ssky-mcp:$VERSION
+        \`\`\`
+        
+        See the full changelog below for detailed information about changes in this release.
+        EOF
+
+    - name: Create GitHub Release
+      uses: softprops/action-gh-release@v1
+      with:
+        body_path: release_notes.md
+        draft: false
+        prerelease: false
+        generate_release_notes: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
## Summary
Restore `.github/workflows/release.yml`, which was removed by mistake in 90e87df.

This is a straight revert of that removal — the workflow file is byte-for-byte identical to the pre-removal version.

## Why
The tag-triggered release automation is still needed: on pushing a `v*` tag it builds and publishes the package to PyPI (`PYPI_API_TOKEN`), pushes the MCP Docker image to `ghcr.io`, and creates the GitHub Release. The `PYPI_API_TOKEN` secret is still configured.

Needed before tagging `v0.4.0`.
