### PR TITLE
docs: note tag-triggered automated release in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,9 @@ preserve it via `conftest.py`).
 - **Repositories**: upstream is `simpleskyclient/ssky`; `mkyutani/ssky` is the dev fork.
   File **issues** and **PRs** against upstream (push to fork first). Confirm repo
   ownership before any GitHub operation.
+- **Releasing is automated, not manual.** Bump `version` in `pyproject.toml`, then push
+  a `v*` tag to upstream — the `release.yml` GitHub Actions workflow handles PyPI publish,
+  Docker image push to ghcr, and the GitHub Release. Don't run `poetry publish` by hand.
 
 ## Safety for posting features
 


### PR DESCRIPTION
Document that releases are automated: bump `version` in `pyproject.toml`, push a `v*` tag to upstream, and `release.yml` handles PyPI publish, ghcr Docker push, and the GitHub Release. No manual `poetry publish`.