### PR TITLE
Add alt text, language tags, video, and reply/quote controls to post

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,24 @@ export SSKY_CONFIG_PATH=~/.ssky-test
 # Simple post
 ssky post "Hello, Bluesky!"
 
-# Post with images
-ssky post "Check out these photos!" --image photo1.jpg --image photo2.jpg
+# Post with images (add alt text in the same order as --image)
+ssky post "Check out these photos!" --image photo1.jpg --image photo2.jpg --alt "a cat" --alt "a dog"
+
+# Post a video
+ssky post "My clip" --video clip.mp4 --video-alt "a short clip"
+
+# Tag the language(s) of the post
+ssky post "こんにちは" --lang ja
 
 # Reply to a post
 ssky post "Great post!" --reply-to at://did:plc:.../app.bsky.feed.post/...
 
 # Quote a post
 ssky post "Interesting!" --quote at://did:plc:.../app.bsky.feed.post/...
+
+# Restrict who can reply (threadgate) and disable quote posts (postgate)
+ssky post "Announcement" --allow-reply following --allow-reply mentioned --no-quote
+ssky post "Private thought" --allow-reply nobody
 ```
 
 ### Reading

--- a/src/ssky/main.py
+++ b/src/ssky/main.py
@@ -60,11 +60,17 @@ def parse():
 
     post_parser = sp.add_parser('post', formatter_class=SortingHelpFormatter, parents=[delimiter_options, format_options], help='Post a message to the timeline')
     post_parser.add_argument('message', nargs='?', type=str, help='The message to post')
+    post_parser.add_argument('--alt', action='append', type=str, default=[], metavar='TEXT', help='Alt text for an image (repeat in the same order as -i)')
+    post_parser.add_argument('--allow-reply', action='append', type=str, default=None, dest='allow_reply', choices=['nobody', 'following', 'follower', 'mentioned'], metavar='WHO', help='Restrict who can reply (threadgate); repeatable. Omit for everybody')
     post_parser.add_argument('-d', '--dry', action='store_true', help='Dry run')
     post_parser.add_argument('-i', '--image', action='append', type=str, default=[], metavar='PATH', help='Image files to attach')
+    post_parser.add_argument('--lang', action='append', type=str, default=[], metavar='LANG', help='Language code of the post (repeatable, e.g. ja, en)')
+    post_parser.add_argument('--no-quote', action='store_true', dest='no_quote', help='Disallow quote posts of this post (postgate)')
     post_parser.add_argument('--no-split', action='store_true', dest='no_split', help='Disable automatic thread splitting for long posts')
     post_parser.add_argument('-q', '--quote', type=str, default=None, metavar='URI', help='Quote a post')
     post_parser.add_argument('-r', '--reply-to', type=str, default=None, metavar='URI', help='Reply to a post')
+    post_parser.add_argument('-v', '--video', type=str, default=None, metavar='PATH', help='Video file to attach (cannot be combined with -i)')
+    post_parser.add_argument('--video-alt', type=str, default=None, dest='video_alt', metavar='TEXT', help='Alt text for the attached video')
 
     profile_parser = sp.add_parser('profile', formatter_class=SortingHelpFormatter, parents=[delimiter_options, format_options], help='Show profile')
     profile_parser.add_argument('actor', type=str, metavar='NAME', help='Handle, DID, or "myself" to show')

--- a/src/ssky/post.py
+++ b/src/ssky/post.py
@@ -1,17 +1,18 @@
 import re
 import sys
-from atproto import IdResolver, models
+from atproto import DidInMemoryCache, IdResolver, models
 import atproto_client
 from bs4 import BeautifulSoup
 import requests
 from ssky.ssky_session import ssky_client
 from ssky.post_data_list import PostDataList
 from ssky.result import (
-    DryRunResult, 
+    DryRunResult,
     AtProtocolSskyError,
-    SessionError, 
-    NotFoundError, 
-    TooManyImagesError
+    SessionError,
+    NotFoundError,
+    TooManyImagesError,
+    InvalidOptionCombinationError
 )
 from ssky.util import disjoin_uri_cid, is_joined_uri_cid
 from time import sleep
@@ -20,6 +21,11 @@ import atproto_client.exceptions
 
 # Configure logger for post module
 logger = logging.getLogger(__name__)
+
+# Shared DID cache so repeated handle->DID resolutions (e.g. the same mention
+# resolved across original/modified message passes) hit the cache instead of
+# re-issuing DNS/HTTP lookups.
+_did_cache = DidInMemoryCache()
 
 def get_card(links, warnings=None):
     if warnings is None:
@@ -225,11 +231,13 @@ def get_tags(message):
 
 def get_mentions(message):
     mentions = search_items(message, r'@[\w.]+', 'handle')
-    for key in mentions:
-        name = mentions[key]['handle'][1:]
-        resolver = IdResolver()
-        did = resolver.handle.resolve(name)
-        mentions[key]['did'] = did
+    if mentions:
+        # Reuse a single resolver (with a shared cache) instead of constructing
+        # one per mention.
+        resolver = IdResolver(cache=_did_cache)
+        for key in mentions:
+            name = mentions[key]['handle'][1:]
+            mentions[key]['did'] = resolver.handle.resolve(name)
     return mentions
 
 def get_thumbnail(uri, warnings=None):
@@ -283,6 +291,30 @@ def load_images(image_paths):
             images.append(f.read())
     return images
 
+def load_video(video_path):
+    with open(video_path, 'rb') as f:
+        return f.read()
+
+def build_image_alts(image, alt):
+    """Align alt texts with images by order. Returns None when no images,
+    otherwise a list of the same length as the images (missing alts -> '')."""
+    if not image:
+        return None
+    image_list = image if isinstance(image, list) else [image]
+    alt_list = alt or []
+    return [alt_list[i] if i < len(alt_list) else '' for i in range(len(image_list))]
+
+def build_dry_run_images(image, image_alts):
+    """Build the images structure (path + alt_text dicts) for DryRunResult."""
+    if not image:
+        return []
+    image_list = image if isinstance(image, list) else [image]
+    alts = image_alts or []
+    return [
+        {'path': path, 'alt_text': alts[i] if i < len(alts) else ''}
+        for i, path in enumerate(image_list)
+    ]
+
 def get_post(uri_cid):
     if is_joined_uri_cid(uri_cid):
         uri, cid = disjoin_uri_cid(uri_cid)
@@ -309,6 +341,49 @@ def get_root_strong_ref(post):
         return models.create_strong_ref(post)
     else:
         return retrieved_post.value.reply.root
+
+_THREADGATE_RULES = {
+    'following': models.AppBskyFeedThreadgate.FollowingRule,
+    'follower': models.AppBskyFeedThreadgate.FollowerRule,
+    'mentioned': models.AppBskyFeedThreadgate.MentionRule,
+}
+
+def apply_post_gates(client, post_uri, allow_reply=None, no_quote=False):
+    """Attach threadgate (reply control) and/or postgate (quote control) records
+    to a just-created post.
+
+    Args:
+        client: Authenticated atproto client
+        post_uri: at:// URI of the root post
+        allow_reply: None for no restriction (everybody). A list of
+            {'nobody','following','follower','mentioned'} otherwise; 'nobody'
+            (or an empty rule set) means no one can reply.
+        no_quote: When True, disallow quote posts of this post.
+    """
+    from datetime import datetime, timezone
+
+    # at://<did>/app.bsky.feed.post/<rkey>
+    parts = post_uri.split('/')
+    repo = parts[2]
+    rkey = parts[-1]
+    created_at = datetime.now(timezone.utc).isoformat().replace('+00:00', 'Z')
+
+    if allow_reply is not None:
+        allow = [_THREADGATE_RULES[who]() for who in allow_reply if who in _THREADGATE_RULES]
+        record = models.AppBskyFeedThreadgate.Record(
+            post=post_uri,
+            allow=allow,
+            created_at=created_at
+        )
+        client.app.bsky.feed.threadgate.create(repo, record, rkey=rkey)
+
+    if no_quote:
+        record = models.AppBskyFeedPostgate.Record(
+            post=post_uri,
+            embedding_rules=[models.AppBskyFeedPostgate.DisableRule()],
+            created_at=created_at
+        )
+        client.app.bsky.feed.postgate.create(repo, record, rkey=rkey)
 
 # Thread splitting constants and functions
 THREAD_MAX_CHARS = 285  # Effective limit per post (excluding prefix and continuation marks)
@@ -514,15 +589,23 @@ def split_text_with_facets(text, links_dict, mentions_dict, tags_dict, max_chars
 
     return result
 
-def post_as_thread(parts_with_facets, images=None, reply_to=None, quote=None, warnings=None):
+def post_as_thread(parts_with_facets, images=None, image_alts=None, video=None,
+                   video_alt=None, reply_to=None, quote=None, langs=None,
+                   allow_reply=None, no_quote=False, warnings=None):
     """
     Post multiple parts as a thread.
 
     Args:
         parts_with_facets: Output from split_text_with_facets()
         images: Images to attach (only to first post)
+        image_alts: Alt texts for images (only to first post)
+        video: Video bytes to attach (only to first post)
+        video_alt: Alt text for the video
         reply_to: Optional reply target
         quote: Optional quote target
+        langs: Optional list of language codes applied to every post
+        allow_reply: Optional reply restriction (threadgate) for the root post
+        no_quote: When True, disallow quote posts of the root post (postgate)
         warnings: Warning list to append to
 
     Returns:
@@ -530,6 +613,7 @@ def post_as_thread(parts_with_facets, images=None, reply_to=None, quote=None, wa
     """
     if warnings is None:
         warnings = []
+    langs = langs or None
 
     client = ssky_client()
     posted = []
@@ -598,6 +682,21 @@ def post_as_thread(parts_with_facets, images=None, reply_to=None, quote=None, wa
                         cid=source.cid
                     )
                 )
+            elif video:
+                # Handle video
+                result = client.send_video(
+                    text=text,
+                    facets=facets if facets else None,
+                    video=video,
+                    video_alt=video_alt,
+                    langs=langs,
+                    reply_to=reply_to
+                )
+                root_ref = models.create_strong_ref(result)
+                parent_ref = root_ref
+                posted.append(result)
+                sleep(0.5)
+                continue
             elif images:
                 # Handle images
                 images_data = load_images(images if isinstance(images, list) else [images])
@@ -605,6 +704,8 @@ def post_as_thread(parts_with_facets, images=None, reply_to=None, quote=None, wa
                     text=text,
                     facets=facets if facets else None,
                     images=images_data,
+                    image_alts=image_alts,
+                    langs=langs,
                     reply_to=reply_to
                 )
                 root_ref = models.create_strong_ref(result)
@@ -627,12 +728,14 @@ def post_as_thread(parts_with_facets, images=None, reply_to=None, quote=None, wa
                 text=text,
                 facets=facets if facets else None,
                 embed=embed,
+                langs=langs,
                 reply_to=current_reply_to
             )
         else:
             result = client.send_post(
                 text=text,
                 facets=facets if facets else None,
+                langs=langs,
                 reply_to=current_reply_to
             )
 
@@ -643,6 +746,10 @@ def post_as_thread(parts_with_facets, images=None, reply_to=None, quote=None, wa
 
         posted.append(result)
         sleep(0.5)
+
+    # Apply reply/quote controls to the root post
+    if posted and (allow_reply is not None or no_quote):
+        apply_post_gates(client, posted[0].uri, allow_reply=allow_reply, no_quote=no_quote)
 
     # Wait for all posts to be available
     result_posts = []
@@ -663,13 +770,22 @@ def post_as_thread(parts_with_facets, images=None, reply_to=None, quote=None, wa
 
     return post_list
 
-def post(message=None, image=None, dry=False, reply_to=None, quote=None, no_split=False, **kwargs):
+def post(message=None, image=None, dry=False, reply_to=None, quote=None, no_split=False,
+         alt=None, lang=None, video=None, video_alt=None, allow_reply=None, no_quote=False,
+         **kwargs):
     warnings = []  # Collect warnings during processing
 
     try:
         current_session = ssky_client()
         if current_session is None:
             raise SessionError()
+
+        # Normalize new options
+        langs = lang or None
+        if video and image:
+            raise InvalidOptionCombinationError("Cannot combine --video with --image")
+        image_alts = build_image_alts(image, alt)
+        video_data = load_video(video) if video else None
 
         # Process message and extract facets
         if message:
@@ -752,11 +868,8 @@ def post(message=None, image=None, dry=False, reply_to=None, quote=None, no_spli
                     for part in parts:
                         preview_parts.append(part['text'])
 
-                    images_list = []
-                    if image:
-                        images_list = image if isinstance(image, list) else [image]
-                        if len(images_list) > 4:
-                            raise TooManyImagesError()
+                    if image and len(image if isinstance(image, list) else [image]) > 4:
+                        raise TooManyImagesError()
 
                     # Return dry run result with thread preview
                     return DryRunResult(
@@ -764,18 +877,29 @@ def post(message=None, image=None, dry=False, reply_to=None, quote=None, no_spli
                         tags=tags,
                         links=links,
                         mentions=mentions,
-                        images=images_list,
+                        images=build_dry_run_images(image, image_alts),
                         card=None,
                         reply_to=reply_to,
-                        quote=quote
+                        quote=quote,
+                        langs=langs,
+                        video=video,
+                        video_alt=video_alt,
+                        allow_reply=allow_reply,
+                        no_quote=no_quote
                     )
 
                 # Post as thread
                 return post_as_thread(
                     parts,
                     images=image,
+                    image_alts=image_alts,
+                    video=video_data,
+                    video_alt=video_alt,
                     reply_to=reply_to,
                     quote=quote,
+                    langs=langs,
+                    allow_reply=allow_reply,
+                    no_quote=no_quote,
                     warnings=warnings
                 )
 
@@ -796,23 +920,23 @@ def post(message=None, image=None, dry=False, reply_to=None, quote=None, no_spli
         
         # Handle dry run
         if dry:
-            # Build preview data
-            images_list = []
-            
-            if image:
-                images_list = image if isinstance(image, list) else [image]
-                if len(images_list) > 4:
-                    raise TooManyImagesError()
-            
+            if image and len(image if isinstance(image, list) else [image]) > 4:
+                raise TooManyImagesError()
+
             return DryRunResult(
                 message=message or "",
                 tags=tags,
                 links=links,
                 mentions=mentions,
-                images=images_list,
+                images=build_dry_run_images(image, image_alts),
                 card=card,
                 reply_to=reply_to,
-                quote=quote
+                quote=quote,
+                langs=langs,
+                video=video,
+                video_alt=video_alt,
+                allow_reply=allow_reply,
+                no_quote=no_quote
             )
         
         # Validate inputs
@@ -879,7 +1003,17 @@ def post(message=None, image=None, dry=False, reply_to=None, quote=None, no_spli
                     cid = source.cid
                 )
             )
-            result = current_session.send_post(text=message or "", facets=facets, embed=embed_record, reply_to=reply_ref)
+            result = current_session.send_post(text=message or "", facets=facets, embed=embed_record, langs=langs, reply_to=reply_ref)
+        elif video_data is not None:
+            # Handle video with send_video method
+            result = current_session.send_video(
+                text=message or "",
+                facets=facets,
+                video=video_data,
+                video_alt=video_alt,
+                langs=langs,
+                reply_to=reply_ref
+            )
         elif image:
             # Handle images with send_images method
             images = load_images(image if isinstance(image, list) else [image])
@@ -887,6 +1021,8 @@ def post(message=None, image=None, dry=False, reply_to=None, quote=None, no_spli
                 text=message or "",
                 facets=facets,
                 images=images,
+                image_alts=image_alts,
+                langs=langs,
                 reply_to=reply_ref
             )
         else:
@@ -894,9 +1030,14 @@ def post(message=None, image=None, dry=False, reply_to=None, quote=None, no_spli
             result = current_session.send_post(
                 text=message or "",
                 facets=facets,
+                langs=langs,
                 reply_to=reply_ref
             )
-        
+
+        # Apply reply/quote controls
+        if allow_reply is not None or no_quote:
+            apply_post_gates(current_session, result.uri, allow_reply=allow_reply, no_quote=no_quote)
+
         # Wait for post to be available and return it
         post = get_post(result.uri)
         while post is None:

--- a/src/ssky/result.py
+++ b/src/ssky/result.py
@@ -82,9 +82,11 @@ class SuccessResult:
 class DryRunResult:
     """Represents a dry run result with detailed information about what would be posted."""
     
-    def __init__(self, message: str, tags: list = None, links: list = None, 
-                 mentions: list = None, images: list = None, card: dict = None, 
-                 reply_to: str = None, quote: str = None):
+    def __init__(self, message: str, tags: list = None, links: list = None,
+                 mentions: list = None, images: list = None, card: dict = None,
+                 reply_to: str = None, quote: str = None, langs: list = None,
+                 video: str = None, video_alt: str = None, allow_reply: list = None,
+                 no_quote: bool = False):
         self.message = message
         self.tags = tags or []
         self.links = links or []
@@ -93,6 +95,11 @@ class DryRunResult:
         self.card = card
         self.reply_to = reply_to
         self.quote = quote
+        self.langs = langs or []
+        self.video = video
+        self.video_alt = video_alt
+        self.allow_reply = allow_reply
+        self.no_quote = no_quote
 
     def to_json(self) -> str:
         """Convert to JSON format."""
@@ -111,9 +118,14 @@ class DryRunResult:
             ],
             "card": self.card,
             "reply_to": self.reply_to,
-            "quote": self.quote
+            "quote": self.quote,
+            "langs": self.langs,
+            "video": self.video,
+            "video_alt": self.video_alt,
+            "allow_reply": self.allow_reply,
+            "no_quote": self.no_quote
         }
-        
+
         response = {
             "status": "ok",
             "http_code": 200,
@@ -134,7 +146,11 @@ class DryRunResult:
             "images": len(self.images),
             "has_card": self.card is not None,
             "has_reply_to": self.reply_to is not None,
-            "has_quote": self.quote is not None
+            "has_quote": self.quote is not None,
+            "langs": self.langs,
+            "has_video": self.video is not None,
+            "allow_reply": self.allow_reply,
+            "no_quote": self.no_quote
         }
         
         return json.dumps(data, ensure_ascii=False, separators=(',', ':'))
@@ -168,16 +184,34 @@ class DryRunResult:
                 image_info.append(info)
             items.append(f"Images: {', '.join(image_info)}")
         
+        # Video
+        if self.video:
+            info = self.video
+            if self.video_alt:
+                info += f" (alt: {self.video_alt})"
+            items.append(f"Video: {info}")
+
         # Card
         if self.card:
             items.append(f"Card: {self.card.get('title', 'Unknown')}")
-        
+
         # Reply and Quote
         if self.reply_to:
             items.append(f"Reply to: {self.reply_to}")
         if self.quote:
             items.append(f"Quote: {self.quote}")
-        
+
+        # Languages
+        if self.langs:
+            items.append(f"Languages: {', '.join(self.langs)}")
+
+        # Reply/quote controls
+        if self.allow_reply is not None:
+            who = ', '.join(self.allow_reply) if self.allow_reply else 'nobody'
+            items.append(f"Allow reply: {who}")
+        if self.no_quote:
+            items.append("Quote posts: disabled")
+
         return items
 
     def print(self, format: str, output: str = None, delimiter: str = ' ') -> None:

--- a/src/ssky_mcp/server.py
+++ b/src/ssky_mcp/server.py
@@ -152,25 +152,38 @@ def ssky_get(
 
 @mcp.tool()  
 def ssky_post(
-    message: str = "", 
-    dry_run: bool = False, 
-    images: str = "", 
-    quote_uri: str = "", 
-    reply_to_uri: str = "", 
-    delimiter: str = "", 
+    message: str = "",
+    dry_run: bool = False,
+    images: str = "",
+    image_alts: str = "",
+    video: str = "",
+    video_alt: str = "",
+    langs: str = "",
+    quote_uri: str = "",
+    reply_to_uri: str = "",
+    allow_reply: str = "",
+    no_quote: bool = False,
+    delimiter: str = "",
     output_dir: str = ""
 ) -> str:
     """Post message to Bluesky
-    
+
     Args:
         message: The message to post
         dry_run: If True, show what would be posted without actually posting
         images: Comma-separated list of image file paths to attach
+        image_alts: Comma-separated alt texts, in the same order as images
+        video: Path to a video file to attach (cannot be combined with images)
+        video_alt: Alt text for the attached video
+        langs: Comma-separated language codes of the post (e.g. "ja,en")
         quote_uri: URI of post to quote (at://...)
         reply_to_uri: URI of post to reply to (at://...)
+        allow_reply: Comma-separated reply restriction (threadgate): any of
+            nobody, following, follower, mentioned. Empty means everybody
+        no_quote: If True, disallow quote posts of this post (postgate)
         delimiter: Custom delimiter string
         output_dir: Output to files in specified directory
-    
+
     Returns:
         JSON string with post result:
         Success:
@@ -202,14 +215,43 @@ def ssky_post(
         image_paths = [path.strip() for path in images.split(",") if path.strip()]
         for image_path in image_paths:
             args.extend(["--image", image_path])
-    
+
+    # Add image alt texts if specified
+    if image_alts:
+        for alt_text in image_alts.split(","):
+            args.extend(["--alt", alt_text.strip()])
+
+    # Add video if specified
+    if video:
+        args.extend(["--video", video])
+    if video_alt:
+        args.extend(["--video-alt", video_alt])
+
+    # Add language tags if specified
+    if langs:
+        for lang in langs.split(","):
+            lang = lang.strip()
+            if lang:
+                args.extend(["--lang", lang])
+
     # Add quote option if specified
     if quote_uri:
         args.extend(["--quote", quote_uri])
-    
+
     # Add reply-to option if specified
     if reply_to_uri:
         args.extend(["--reply-to", reply_to_uri])
+
+    # Add reply restriction (threadgate) if specified
+    if allow_reply:
+        for who in allow_reply.split(","):
+            who = who.strip()
+            if who:
+                args.extend(["--allow-reply", who])
+
+    # Disallow quote posts (postgate) if requested
+    if no_quote:
+        args.append("--no-quote")
     
     # Always use simple-json for MCP
     args.append("--simple-json")

--- a/tests/test_post_and_delete.py
+++ b/tests/test_post_and_delete.py
@@ -441,3 +441,96 @@ class TestPostDeleteSequential:
         mentions_empty = get_mentions(message_no_mentions)
         assert len(mentions_empty) == 0
 
+
+class TestPostNewOptions:
+    """Tests for langs, image alt text, video, and reply/quote controls."""
+
+    def _mock_client(self):
+        from tests.common import create_mock_ssky_session
+        mock_session, mock_client, mock_profile = create_mock_ssky_session()
+
+        for attr in ('send_post', 'send_images', 'send_video'):
+            resp = Mock()
+            resp.uri = "at://did:plc:test123/app.bsky.feed.post/test123"
+            resp.cid = "testcid123"
+            getattr(mock_client, attr).return_value = resp
+
+        retrieved = Mock()
+        retrieved.uri = "at://did:plc:test123/app.bsky.feed.post/test123"
+        retrieved.cid = "testcid123"
+        retrieved.author = Mock()
+        retrieved.author.did = "did:plc:test123"
+        retrieved.author.handle = "test.bsky.social"
+        retrieved.record = Mock()
+        retrieved.record.text = "Test"
+        posts_resp = Mock()
+        posts_resp.posts = [retrieved]
+        mock_client.get_posts.return_value = posts_resp
+        return mock_client
+
+    def test_dry_run_lang(self):
+        result = post(message="Hello", lang=["ja", "en"], dry=True)
+        assert isinstance(result, DryRunResult)
+        assert result.langs == ["ja", "en"]
+        assert "Languages: ja, en" in result.to_list()
+
+    def test_dry_run_image_alt(self):
+        result = post(message="pic", image=["a.png", "b.png"], alt=["first"], dry=True)
+        assert isinstance(result, DryRunResult)
+        assert result.images[0]["alt_text"] == "first"
+        assert result.images[1]["alt_text"] == ""
+
+    def test_dry_run_allow_reply_and_no_quote(self):
+        result = post(message="locked", allow_reply=["following", "mentioned"], no_quote=True, dry=True)
+        assert isinstance(result, DryRunResult)
+        assert result.allow_reply == ["following", "mentioned"]
+        assert result.no_quote is True
+        items = result.to_list()
+        assert "Allow reply: following, mentioned" in items
+        assert "Quote posts: disabled" in items
+
+    def test_video_image_mutually_exclusive(self):
+        from ssky.result import InvalidOptionCombinationError
+        with patch('ssky.post.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = self._mock_client()
+            with pytest.raises(InvalidOptionCombinationError):
+                post(message="x", image=["a.png"], video="v.mp4")
+
+    def test_video_post_calls_send_video(self, tmp_path):
+        video_file = tmp_path / "clip.mp4"
+        video_file.write_bytes(b"fakevideo")
+        client = self._mock_client()
+        with patch('ssky.post.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = client
+            result = post(message="watch", video=str(video_file), video_alt="a clip", lang=["en"])
+            assert isinstance(result, PostDataList)
+            client.send_video.assert_called_once()
+            kwargs = client.send_video.call_args.kwargs
+            assert kwargs["video"] == b"fakevideo"
+            assert kwargs["video_alt"] == "a clip"
+            assert kwargs["langs"] == ["en"]
+
+    def test_image_post_passes_alts_and_langs(self, tmp_path):
+        img = tmp_path / "p.png"
+        img.write_bytes(b"img")
+        client = self._mock_client()
+        with patch('ssky.post.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = client
+            result = post(message="pic", image=[str(img)], alt=["alt text"], lang=["ja"])
+            assert isinstance(result, PostDataList)
+            kwargs = client.send_images.call_args.kwargs
+            assert kwargs["image_alts"] == ["alt text"]
+            assert kwargs["langs"] == ["ja"]
+
+    def test_allow_reply_creates_threadgate(self):
+        client = self._mock_client()
+        with patch('ssky.post.ssky_client') as mock_ssky_client:
+            mock_ssky_client.return_value = client
+            result = post(message="locked", allow_reply=["nobody"], no_quote=True)
+            assert isinstance(result, PostDataList)
+            client.app.bsky.feed.threadgate.create.assert_called_once()
+            client.app.bsky.feed.postgate.create.assert_called_once()
+            # 'nobody' => empty allow rule list
+            tg_record = client.app.bsky.feed.threadgate.create.call_args.args[1]
+            assert tg_record.allow == []
+


### PR DESCRIPTION
## Summary

Leverages newer `atproto` (0.0.68) capabilities to extend `ssky post` with several additive features and a small perf improvement. No breaking changes.

### Posting features
- **Image alt text** — `--alt TEXT` (repeat in the same order as `-i/--image`), passed via `send_images(image_alts=...)`.
- **Language tags** — `--lang LANG` (repeatable), passed via `langs=...` on all send paths.
- **Video posting** — `-v/--video PATH` + `--video-alt TEXT` using `client.send_video`. Mutually exclusive with `--image`.
- **Reply control (threadgate)** — `--allow-reply {nobody,following,follower,mentioned}` (repeatable).
- **Quote control (postgate)** — `--no-quote` disallows quote posts.

Gates are applied to the root post (including the root of an auto-split thread).

### Performance
- **Cached mention resolution** — reuse a single `IdResolver` with a shared `DidInMemoryCache` instead of constructing one per mention.

### Other
- `DryRunResult` surfaces the new fields (text / json / simple_json) and now represents images as `{path, alt_text}` (also fixes a latent dict/str mismatch in dry-run image rendering).
- MCP `ssky_post` tool exposes the new options for CLI/MCP parity.
- README usage examples updated.

## Testing
- `SSKY_SKIP_REAL_API_TESTS=1 poetry run python -m pytest` → 145 passed, 1 skipped.
- Added 7 tests covering dry-run rendering, video/image exclusivity, and `send_video` / `image_alts` / `langs` / threadgate call wiring.