### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ssky"
-version = "0.4.0"
+version = "1.0.0"
 description = "Simple bluesky client"
 authors = [
     {name = "SimpleSkyClient Project", email = "simpleskypclient@gmail.com"}


### PR DESCRIPTION
## Summary

Bump `version` to **1.0.0**, declaring the CLI and output formats a stable public API.

This follows PR #63, which added image alt text, language tags, video posting, and reply/quote controls (threadgate/postgate) plus cached mention resolution — all backward-compatible additions.

## Release
After merge, pushing the `v1.0.0` tag to upstream triggers `release.yml` (PyPI publish, ghcr image, GitHub Release).