### PR TITLE
Bump release workflow actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.12'
 
@@ -44,10 +44,10 @@ jobs:
         poetry publish
 
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
 
     - name: Log in to Container Registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.REGISTRY }}
         username: ${{ github.actor }}
@@ -55,7 +55,7 @@ jobs:
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@v6
       with:
         images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
         tags: |
@@ -65,7 +65,7 @@ jobs:
           type=raw,value=latest
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v5
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./mcp/Dockerfile
@@ -107,7 +107,7 @@ jobs:
         EOF
 
     - name: Create GitHub Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v3
       with:
         body_path: release_notes.md
         draft: false


### PR DESCRIPTION
## Summary

The `v1.0.0` release run emitted a deprecation annotation: several actions still run on Node.js 20, which GitHub will force to Node.js 24 starting 2026-06-16 and remove from runners on 2026-09-16.

Bumps each flagged action to its latest major:

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/setup-python | v4 | v6 |
| docker/setup-buildx-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/build-push-action | v5 | v7 |
| softprops/action-gh-release | v1 | v3 |

`snok/install-poetry@v1` was not flagged and is left as-is.

## Notes
Workflow only runs on `v*` tag push, so this takes effect on the next release. No behavioral changes to build/publish steps.