### PR TITLE
fix: surface real authentication error on login failure

### DIFF
--- a/src/ssky/login.py
+++ b/src/ssky/login.py
@@ -26,6 +26,10 @@ def login(credentials=None, **kwargs) -> ProfileList:
 
         profile = session.profile()
         if profile is None or not hasattr(profile, 'did') or profile.did is None:
+            # Surface the real authentication error if login actually failed,
+            # instead of a generic "profile not available" message.
+            if SskySession.login_error is not None:
+                raise AtProtocolSskyError(SskySession.login_error) from SskySession.login_error
             raise ProfileUnavailableAfterLoginError()
         
         return ProfileList().append(profile.did)

--- a/src/ssky/ssky_session.py
+++ b/src/ssky/ssky_session.py
@@ -20,6 +20,10 @@ class SskySession:
 
     login_failed = Session()
 
+    # Holds the last AtProtocolError that caused a login failure, so callers
+    # can surface the real reason instead of a generic message.
+    login_error = None
+
     class Status:
         NOT_LOGGED_IN = 0,
         LOGGED_IN = 1,
@@ -59,8 +63,9 @@ class SskySession:
                         cls.session = cls.at_login_internal(handle=handle, password=password)
                         # Auto-persist session after successful login
                         cls.persist_internal()
-                    except atproto_client.exceptions.AtProtocolError:
+                    except atproto_client.exceptions.AtProtocolError as e:
                         cls.session = cls.login_failed
+                        cls.login_error = e
                         # Don't re-raise, let the caller handle the failed session state
                 # Try environment variable (fallback)
                 elif var_user is not None:
@@ -69,8 +74,9 @@ class SskySession:
                         cls.session = cls.at_login_internal(handle=handle, password=password)
                         # Auto-persist session after successful login
                         cls.persist_internal()
-                    except atproto_client.exceptions.AtProtocolError:
+                    except atproto_client.exceptions.AtProtocolError as e:
                         cls.session = cls.login_failed
+                        cls.login_error = e
                         # Don't re-raise, let the caller handle the failed session state
                 else:
                     cls.session = cls.login_failed
@@ -97,6 +103,7 @@ class SskySession:
     @classmethod
     def clear(cls) -> None:
         cls.session = None
+        cls.login_error = None
 
     def __init__(self, handle=None, password=None):
         SskySession.login_internal(handle=handle, password=password)


### PR DESCRIPTION
## Problem

Running `ssky login handle:password` with invalid credentials reports a misleading message:

```
Profile not available after login
```

The real authentication error (e.g. `Invalid identifier or password`) is swallowed in `SskySession.login_internal`, where the `AtProtocolError` from `at_login_internal` is caught and converted to a `login_failed` state without being re-raised or stored. `login.py` then only sees `profile is None` and raises the generic `ProfileUnavailableAfterLoginError`, hiding the actual cause from the user.

## Fix

- `ssky_session.py`: store the caught `AtProtocolError` on `SskySession.login_error` (for both the command-line credentials and `SSKY_USER` paths), and reset it in `clear()`. The failed-session behavior is unchanged, so other commands that rely on a `None` client keep working.
- `login.py`: when the profile is unavailable after login, surface the stored error as `AtProtocolSskyError` if present; otherwise fall back to `ProfileUnavailableAfterLoginError`.

## Result

```
$ ssky login notauser.invalid:wrongpassword
Invalid identifier or password
```

## Testing

`SSKY_SKIP_REAL_API_TESTS=1 poetry run pytest tests/test_login.py` — 9 passed.