### PR TITLE
fix: require whitespace boundary and non-digit body for hashtag detection

### DIFF
--- a/src/ssky/post.py
+++ b/src/ssky/post.py
@@ -1,5 +1,6 @@
 import re
 import sys
+import unicodedata
 from atproto import DidInMemoryCache, IdResolver, models
 import atproto_client
 from bs4 import BeautifulSoup
@@ -226,8 +227,53 @@ def search_items(text, pattern, property_name):
 def get_links(message):
     return search_items(message, r'https?://[\w/:%#\$&\?\(\)~\.=\+\-]+', 'uri')
 
+# Hashtag detection mirrors the reference implementation in @atproto/api
+# (rich-text/util.ts TAG_REGEX): the '#' must start the text or follow
+# whitespace, the tag body must contain at least one character that is neither a
+# digit nor punctuation, and trailing punctuation is dropped. A bare r'#\S+'
+# turns a mid-word '#' ("RFI#1") into a tag that runs to the next whitespace,
+# which in languages without spaces between words swallows the rest of the
+# sentence and exceeds the 64-grapheme limit of app.bsky.feed.post.
+TAG_ZERO_WIDTH_CHARS = '\u00ad\u2060\u200a\u200b\u200c\u200d\u20e2'
+TAG_VARIATION_SELECTOR = '\ufe0f'
+TAG_MAX_GRAPHEMES = 64
+TAG_PATTERN = re.compile(f'(?:^|(?<=\\s))[#\uff03][^\\s{TAG_ZERO_WIDTH_CHARS}]*')
+
+def is_tag_punctuation(char):
+    return unicodedata.category(char).startswith('P')
+
 def get_tags(message):
-    return search_items(message, r'#\S+', 'name')
+    items = {}
+    for m in TAG_PATTERN.finditer(message):
+        # Emoji modifier right after the '#' never starts a tag
+        body = m.group()[1:]
+        if body.startswith(TAG_VARIATION_SELECTOR):
+            continue
+
+        while body and is_tag_punctuation(body[-1]):
+            body = body[:-1]
+
+        # A tag made only of digits and punctuation ("#1", "#...") is not a tag
+        if not any(not ('0' <= c <= '9') and not is_tag_punctuation(c) for c in body):
+            continue
+
+        # A grapheme cluster is never shorter than one code point, so this is a
+        # conservative form of the server-side 64-grapheme check; over-long tags
+        # stay plain text instead of getting the whole post rejected.
+        if len(body) > TAG_MAX_GRAPHEMES:
+            continue
+
+        start = m.start()
+        end = start + 1 + len(body)
+        byte_start = byte_len(message[:start])
+        items[f'{start:05d}'] = {
+            'byte_start': byte_start,
+            'byte_end': byte_start + byte_len(message[start:end]),
+            'start': start,
+            'end': end,
+            'name': message[start:end]
+        }
+    return items
 
 def get_mentions(message):
     mentions = search_items(message, r'@[\w.]+', 'handle')

--- a/tests/test_post_and_delete.py
+++ b/tests/test_post_and_delete.py
@@ -442,6 +442,54 @@ class TestPostDeleteSequential:
         assert len(mentions_empty) == 0
 
 
+class TestTagDetection:
+    """Tag detection follows the @atproto/api rules (issue #68)."""
+
+    def tag_names(self, message):
+        return [item['name'] for item in get_tags(message).values()]
+
+    def test_mid_word_hash_is_not_a_tag(self):
+        """A '#' not preceded by whitespace never starts a tag"""
+        # The reported case: without spaces between words, the runaway tag ran
+        # from '#' to the URL and blew past the 64-grapheme limit
+        message = "情報提供依頼（RFI#1、2027年度向け）として、3D都市モデルの整備・活用に関する知見を募集する。 https://example.com/rfi.html"
+        assert self.tag_names(message) == []
+
+        assert self.tag_names("RFI#1 and WG#2") == []
+        assert self.tag_names("多言語の#日本語タグ") == []
+
+    def test_tag_needs_more_than_digits_and_punctuation(self):
+        assert self.tag_names("Read #1 today") == []
+        assert self.tag_names("Wait #... really") == []
+        assert self.tag_names("Ticket #1a here") == ['#1a']
+
+    def test_trailing_punctuation_is_stripped(self):
+        assert self.tag_names("A #tag. B") == ['#tag']
+        assert self.tag_names("A #a.b here") == ['#a.b']
+
+    def test_tag_at_start_and_after_newline(self):
+        assert self.tag_names("#start of text") == ['#start']
+        assert self.tag_names("line1\n#newline tag") == ['#newline']
+
+    def test_fullwidth_hash_is_a_tag(self):
+        assert self.tag_names("＃全角タグ です") == ['＃全角タグ']
+
+    def test_url_fragment_is_not_a_tag(self):
+        assert self.tag_names("See https://example.com/page#fragment now") == []
+
+    def test_over_long_tag_is_skipped(self):
+        """Tags over the 64-grapheme limit stay plain text instead of failing the post"""
+        assert self.tag_names('#' + 'あ' * 64 + ' ok') == ['#' + 'あ' * 64]
+        assert self.tag_names('#' + 'あ' * 65 + ' too long') == []
+
+    def test_positions_match_the_tag_text(self):
+        message = "先頭 #タグ と #another です"
+        for item in get_tags(message).values():
+            name = item['name']
+            assert message[item['start']:item['end']] == name
+            assert message.encode('utf-8')[item['byte_start']:item['byte_end']].decode('utf-8') == name
+
+
 class TestPostNewOptions:
     """Tests for langs, image alt text, video, and reply/quote controls."""
 


### PR DESCRIPTION
Fixes #68.

## What changed

`get_tags()` matched `#\S+` anywhere in the text, so a mid-word `#` (`RFI#1`) started a tag that ran to the next whitespace. In languages without spaces between words that swallows the rest of the sentence, exceeding the 64-grapheme limit of `app.bsky.feed.post` and getting the whole record rejected.

Detection now follows the reference implementation in `@atproto/api` (`rich-text/util.ts` `TAG_REGEX` + `TRAILING_PUNCTUATION_REGEX`):

- the `#` (or full-width `＃`) must start the text or follow whitespace
- the tag body must contain at least one character that is neither an ASCII digit nor punctuation, so `#1` and `#...` are not tags
- trailing punctuation is stripped (`#tag.` → `tag`), and the facet byte range covers exactly the stripped tag
- zero-width characters and a leading `️` terminate / reject the tag, as in the reference
- tags longer than 64 code points produce no facet and stay plain text (a grapheme cluster is never shorter than one code point, so this is a conservative form of the server-side check)

No truncation, per the discussion in the issue: an over-long run is left as plain text rather than published as a meaningless clickable hashtag.

Side effect: a `#fragment` inside a URL no longer produces a tag facet overlapping the link facet.

## Tests

New `TestTagDetection` in `tests/test_post_and_delete.py` covers the reported Japanese case, `RFI#1` / `WG#2`, digits-and-punctuation-only bodies, trailing punctuation, start-of-text and post-newline tags, full-width `＃`, URL fragments, the 64/65 grapheme boundary, and char/byte position consistency.

`SSKY_SKIP_REAL_API_TESTS=1 poetry run python -m pytest` → 152 passed, 1 skipped, 1 pre-existing failure unrelated to this change (`test_login.py::TestLoginSequential::test_05_login_profile_availability_check`, which fails on `main` too).
