### PR TITLE
chore: bump version to 1.0.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ssky"
-version = "1.0.1"
+version = "1.0.2"
 description = "Simple bluesky client"
 authors = [
     {name = "SimpleSkyClient Project", email = "simpleskypclient@gmail.com"}


### PR DESCRIPTION
Release v1.0.2.

- #69 fix: require whitespace boundary and non-digit body for hashtag detection (fixes #68)