### PR TITLE
refactor: make fastmcp an optional extra and demote Docker to a secondary MCP path

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "poetry install && echo '\n# Auto-activate Poetry virtual environment for ssky project\nif [ -d \"/workspaces/ssky/.venv\" ]; then\n    source /workspaces/ssky/.venv/bin/activate\nfi' >> ~/.bashrc",
+	"postCreateCommand": "poetry install --extras mcp && echo '\n# Auto-activate Poetry virtual environment for ssky project\nif [ -d \"/workspaces/ssky/.venv\" ]; then\n    source /workspaces/ssky/.venv/bin/activate\nfi' >> ~/.bashrc",
 
 	// Configure tool-specific properties.
 	"customizations": {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,8 +97,13 @@ jobs:
         \`\`\`bash
         pip install ssky==$VERSION
         \`\`\`
-        
-        ### Docker
+
+        The MCP server for IDE integration is an optional extra:
+        \`\`\`bash
+        pip install 'ssky[mcp]==$VERSION'
+        \`\`\`
+
+        ### MCP server via Docker (alternative)
         \`\`\`bash
         docker pull ghcr.io/simpleskyclient/ssky-mcp:$VERSION
         \`\`\`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,14 +8,17 @@ ssky is a lightweight command-line Bluesky client. It ships:
 - The `ssky` CLI for posting, searching, and managing Bluesky content (images, quotes, replies, rich text)
 - An MCP server (`src/ssky_mcp/`) for IDE integration
 
-Requires Python 3.12+. Uses Poetry. Key deps: `atproto`, `beautifulsoup4`, `requests`, `fastmcp` (see `pyproject.toml`).
+Requires Python 3.12+. Uses Poetry. Key deps: `atproto`, `beautifulsoup4`, `requests`.
+`fastmcp` is an **optional extra** (`ssky[mcp]`), not a core dependency — a plain
+`pip install ssky` must never pull it (see `pyproject.toml`).
 
 ## Commands
 
 **Always prefix Python/tool commands with `poetry run`** to use the correct venv.
 
 ```bash
-poetry install                                   # install deps
+poetry install --extras mcp                      # install deps (incl. the MCP server)
+poetry install                                   # CLI deps only, as end users get them
 poetry run pytest --tb=short                     # run tests
 poetry run pytest tests/test_login.py -v         # single file
 SSKY_SKIP_REAL_API_TESTS=1 poetry run pytest     # skip real Bluesky API calls
@@ -53,7 +56,15 @@ method. Output formats: `id` (-I), `json` (-J), `long` (-L), `simple_json` (-S),
 ### MCP server (`src/ssky_mcp/server.py`)
 FastMCP server. **Each tool shells out to the `ssky` CLI via `subprocess`**, not Python
 imports — so CLI and MCP behavior are guaranteed identical and a CLI fix is inherited
-automatically. Deployed via Docker (`mcp/`).
+automatically. Do not refactor this into library imports.
+
+Runs over stdio from `pip install 'ssky[mcp]'` (or `uvx`); the Docker image in `mcp/` is a
+secondary path. `fastmcp` is imported through `require_fastmcp()`, which exits with an
+install hint rather than an `ImportError` when the extra is absent.
+
+**Policy: no new MCP tools.** The 10 existing tools are the steady state; MCP capability
+follows the CLI, so improvements belong in the CLI and are inherited for free. Do not add
+MCP-specific features.
 
 ### Authentication
 `ssky_client()` resolves auth in order: session file `~/.ssky` (persisted

--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ A lightweight, command-line Bluesky client that makes it easy to interact with t
 pip install ssky
 ```
 
+This installs the CLI and nothing else. If you also want the MCP server for IDE
+integration, install the optional extra instead:
+
+```bash
+pip install 'ssky[mcp]'
+```
+
 ### Login
 
 ```bash
@@ -243,7 +250,10 @@ ssky get --output ./timeline
 
 **Quick Setup:**
 ```bash
-# For new MCP setup: copy sample configuration (no build required!)
+# Install ssky with the MCP extra
+pip install 'ssky[mcp]'
+
+# Copy the sample configuration
 mkdir -p .cursor
 cp mcp/mcp.sample.json .cursor/mcp.json
 
@@ -253,11 +263,16 @@ export SSKY_USER=your-handle.bsky.social:your-password
 # Restart Cursor to load the MCP tools
 ```
 
-✨ **Docker will automatically pull the pre-built image on first use!**
+The MCP server is a Python process that runs over stdio, so `uvx` works without
+installing anything permanently — see `mcp/mcp.sample.json`.
 
-**Advanced Setup:**
-- **For existing MCP setup**: Add ssky server to your `.cursor/mcp.json` (see `mcp/mcp.sample.json`)
-- **For local development**: Use `cd mcp && ./build.sh && cd ..` to build locally
+**Alternative Setup:**
+- **Docker**: `cp mcp/mcp.docker.sample.json .cursor/mcp.json` uses the pre-built
+  `ghcr.io/simpleskyclient/ssky-mcp` image, which is pulled automatically on first use.
+  Useful if you would rather not have a Python environment involved.
+- **For existing MCP setup**: Add the ssky server to your `.cursor/mcp.json` (see the
+  sample files above)
+- **For local development**: Use `cd mcp && ./build.sh && cd ..` to build the image locally
 - **Complete guide**: See [MCP Documentation](mcp/SSKY_MCP_GUIDE.md)
 
 **Available Tools:**

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -23,8 +23,9 @@ WORKDIR /app/ssky-source
 # Configure Poetry to not create virtual environment (we're in a container)
 RUN poetry config virtualenvs.create false
 
-# Install dependencies and the local ssky package (including the project itself)
-RUN poetry install
+# Install dependencies and the local ssky package (including the project itself).
+# fastmcp lives in the optional "mcp" extra, so it must be requested explicitly.
+RUN poetry install --extras mcp
 
 # Set working directory back to /app and use the installed package
 WORKDIR /app

--- a/mcp/Dockerfile.dev
+++ b/mcp/Dockerfile.dev
@@ -23,8 +23,9 @@ WORKDIR /app/ssky-source
 # Configure Poetry to not create virtual environment (we're in a container)
 RUN poetry config virtualenvs.create false
 
-# Install dependencies and the local ssky package (including the project itself)
-RUN poetry install
+# Install dependencies and the local ssky package (including the project itself).
+# fastmcp lives in the optional "mcp" extra, so it must be requested explicitly.
+RUN poetry install --extras mcp
 
 # Debug: Check where ssky might be installed
 RUN echo "PATH: $PATH"
@@ -36,7 +37,7 @@ RUN ls -la /root/.local/bin/ 2>/dev/null || echo "/root/.local/bin/ not found"
 RUN which ssky || echo "ssky command not found in PATH"
 RUN ssky --help || echo "ssky command failed"
 
-# MCP dependencies are already installed via poetry (fastmcp)
+# MCP dependencies are already installed via poetry (the "mcp" extra)
 
 # Set working directory back to /app and use the installed package
 WORKDIR /app

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -2,6 +2,25 @@
 
 MCP (Model Context Protocol) server for the ssky Bluesky client.
 
+## Running the server
+
+The server is a Python process that speaks MCP over stdio. The primary way to run it is
+to install the optional extra and let the MCP client launch it:
+
+```bash
+pip install 'ssky[mcp]'
+ssky-mcp-server
+```
+
+`mcp/mcp.sample.json` configures this via `uvx`, which needs no permanent install.
+A plain `pip install ssky` does **not** include the MCP server; `ssky-mcp-server` will
+tell you to install `ssky[mcp]` if the extra is missing.
+
+Docker (below) is a secondary option for environments where a Python install is
+inconvenient. Note that the container cannot see the host filesystem, so posting images
+requires a volume mount (see `mcp.docker.sample.json`) — the Python install has no such
+restriction.
+
 ## Building Docker Images
 
 This directory contains scripts and Dockerfiles for building the ssky MCP server as a Docker image.

--- a/mcp/SSKY_MCP_GUIDE.md
+++ b/mcp/SSKY_MCP_GUIDE.md
@@ -13,10 +13,23 @@ The MCP server provides **10 comprehensive tools** for Bluesky interaction:
 ## Setup
 
 ### 1. Requirements
-Before starting, ensure you have the following installed:
 
-#### Docker
-Docker is required to run the MCP server. Install Docker for your platform:
+#### Python Package
+The MCP server ships as an optional extra of the `ssky` package. Install it with:
+```bash
+pip install 'ssky[mcp]'
+```
+
+A plain `pip install ssky` gives you the CLI only — `ssky-mcp-server` will tell you to
+install the extra if it is missing.
+
+If you use [`uv`](https://docs.astral.sh/uv/), nothing needs to be installed permanently;
+`uvx --from 'ssky[mcp]' ssky-mcp-server` fetches it on demand, and that is what the sample
+configuration does.
+
+#### Docker (optional)
+Only needed if you choose the Docker setup below instead of the Python one. Install Docker
+for your platform:
 - **Linux**: Follow the [official Docker installation guide](https://docs.docker.com/engine/install/)
 - **macOS**: Download [Docker Desktop for Mac](https://docs.docker.com/desktop/install/mac-install/)
 - **Windows**: Download [Docker Desktop for Windows](https://docs.docker.com/desktop/install/windows-install/)
@@ -25,12 +38,6 @@ After installation, verify Docker is running:
 ```bash
 docker --version
 docker info
-```
-
-#### Python Package
-Ensure the `ssky` package is installed and available in your PATH:
-```bash
-pip install ssky
 ```
 
 ### 2. Configure Bluesky Authentication
@@ -52,8 +59,12 @@ Create a `.env` file in your project root:
 SSKY_USER=your-handle.bsky.social:your-password
 ```
 
-### 2.1. Configure Image Directory (Optional)
-To enable image posting functionality, the default configuration uses `~/Pictures` directory.
+### 2.1. Configure Image Directory (Docker setup only)
+With the Python setup the server runs as your own user and can read image paths directly —
+pass a normal host path and skip this section.
+
+The Docker container cannot see your filesystem, so images have to be mounted in. The
+sample Docker configuration mounts `~/Pictures`.
 
 #### Setup
 1. Create the Pictures directory if it doesn't exist:
@@ -92,8 +103,8 @@ If you want to use a different directory, modify the volume mount in your MCP co
 
 ### 3. Configure Cursor
 
-#### Option A: Quick Setup (Recommended - No build required)
-If you don't have an existing `.cursor/mcp.json` file, this is the simplest approach using the pre-built Docker image:
+#### Option A: Quick Setup (Recommended)
+If you don't have an existing `.cursor/mcp.json` file, this is the simplest approach:
 
 1. **Copy the sample configuration:**
    ```bash
@@ -106,9 +117,24 @@ If you don't have an existing `.cursor/mcp.json` file, this is the simplest appr
 
 2. **Restart Cursor** to load the MCP tools
 
-✅ **That's it!** Docker will automatically pull the pre-built image (`ghcr.io/simpleskyclient/ssky-mcp:latest`) when first used.
+✅ **That's it!** The configuration runs `uvx --from 'ssky[mcp]' ssky-mcp-server`, so there
+is nothing to build and nothing to install permanently. If you would rather install it,
+`pip install 'ssky[mcp]'` and set `"command": "ssky-mcp-server"` with no `args`.
 
-💡 **Note:** The first use may take a moment for Docker to pull the image (~276MB).
+#### Option B: Docker Setup
+Use this if you would rather not have a Python environment involved. It uses the pre-built
+image, which Docker pulls automatically on first use (~276MB).
+
+1. **Copy the Docker sample configuration:**
+   ```bash
+   mkdir -p .cursor
+   cp mcp/mcp.docker.sample.json .cursor/mcp.json
+   ```
+
+2. **Restart Cursor** to load the MCP tools
+
+Remember that the container cannot see your filesystem: posting images requires the volume
+mount described in section 2.1.
 
 **Available Docker Images:**
 - `ghcr.io/simpleskyclient/ssky-mcp:latest` - Latest stable version (auto-built from main branch)
@@ -116,7 +142,7 @@ If you don't have an existing `.cursor/mcp.json` file, this is the simplest appr
 - **Source**: [GitHub Container Registry](https://github.com/simpleskyclient/ssky-mcp/pkgs/container/ssky-mcp)
 - **CI/CD**: Automatically built via [GitHub Actions](https://github.com/simpleskyclient/ssky/actions)
 
-#### Option B: Add to Existing MCP Configuration
+#### Option C: Add to Existing MCP Configuration
 If you already have `.cursor/mcp.json` with other MCP servers (e.g., GitHub):
 
 1. **Back up your existing configuration:**
@@ -134,25 +160,23 @@ If you already have `.cursor/mcp.json` with other MCP servers (e.g., GitHub):
                // ... your existing configuration
            },
            "ssky": {
-               "command": "docker",
+               "command": "uvx",
                "args": [
-                   "run",
-                   "-i",
-                   "--rm",
-                   "-e",
-                   "SSKY_USER",
-                   "ghcr.io/simpleskyclient/ssky-mcp:latest"
+                   "--from",
+                   "ssky[mcp]",
+                   "ssky-mcp-server"
                ]
            }
        }
    }
    ```
    
-   💡 **Tip:** You can copy the exact configuration from `mcp/mcp.sample.json`
+   💡 **Tip:** You can copy the exact configuration from `mcp/mcp.sample.json`, or from
+   `mcp/mcp.docker.sample.json` for the Docker form.
 
 3. **Restart Cursor** to reload the configuration
 
-#### Option C: Local Build (For Developers)
+#### Option D: Local Build (For Developers)
 If you prefer to build the Docker image locally or need to modify the MCP server:
 
 1. **Build the Docker image:**
@@ -174,7 +198,7 @@ If you prefer to build the Docker image locally or need to modify the MCP server
    mkdir -p .cursor
    
    # Copy and modify for local image
-   sed 's|ghcr.io/simpleskyclient/ssky-mcp:latest|ssky-mcp:latest|' mcp/mcp.sample.json > .cursor/mcp.json
+   sed 's|ghcr.io/simpleskyclient/ssky-mcp:latest|ssky-mcp:latest|' mcp/mcp.docker.sample.json > .cursor/mcp.json
    ```
 
 3. **Restart Cursor** to load the MCP tools
@@ -451,30 +475,35 @@ ssky_post(
 
 ## Troubleshooting
 
-1. **Docker not found**: Ensure Docker is installed and running
+1. **`ssky-mcp-server requires the optional MCP dependencies`**: the `mcp` extra is not
+   installed
+   - Install: `pip install 'ssky[mcp]'`
+   - Verify: `ssky-mcp-server --version`
+
+2. **Docker not found** (Docker setup only): Ensure Docker is installed and running
    - Install Docker from [official website](https://docs.docker.com/get-docker/)
    - Start Docker service: `sudo systemctl start docker` (Linux) or start Docker Desktop
    - Verify: `docker --version` and `docker info`
 
-2. **Command not found**: Ensure `ssky` is installed and in your PATH
-   - Install: `pip install ssky`
+3. **Command not found**: Ensure `ssky` is installed and in your PATH
+   - Install: `pip install 'ssky[mcp]'`
    - Verify: `ssky --help`
 
-3. **Authentication failed**: Check your credentials and network connection
+4. **Authentication failed**: Check your credentials and network connection
    - Verify credentials: `ssky login your-handle.bsky.social:your-password`
    - Check environment variable: `echo $SSKY_USER`
 
-4. **Docker build failed**: Check Docker daemon and permissions
+5. **Docker build failed**: Check Docker daemon and permissions
    - Ensure Docker daemon is running
    - Check user permissions for Docker (may need `sudo` or add user to docker group)
 
-5. **Permission denied**: Ensure proper file permissions
+6. **Permission denied**: Ensure proper file permissions
    - Make build script executable: `chmod +x mcp/build.sh`
 
-6. **Timeout errors**: Operations have a 30-second timeout; network issues may cause delays
+7. **Timeout errors**: Operations have a 30-second timeout; network issues may cause delays
 
-7. **MCP connection issues**: Restart Cursor to reload the MCP server configuration
-   - Verify Docker image exists: `docker images | grep ssky-mcp`
+8. **MCP connection issues**: Restart Cursor to reload the MCP server configuration
+   - Verify Docker image exists (Docker setup only): `docker images | grep ssky-mcp`
    - Check `.cursor/mcp.json` configuration format
 
 ## Advanced Usage

--- a/mcp/mcp.docker.sample.json
+++ b/mcp/mcp.docker.sample.json
@@ -1,0 +1,17 @@
+{
+    "mcpServers": {
+        "ssky": {
+            "command": "docker",
+            "args": [
+                "run",
+                "-i",
+                "--rm",
+                "-v",
+                "~/Pictures:/app/images",
+                "-e",
+                "SSKY_USER",
+                "ghcr.io/simpleskyclient/ssky-mcp:latest"
+            ]
+        }
+    }
+}

--- a/mcp/mcp.sample.json
+++ b/mcp/mcp.sample.json
@@ -1,16 +1,11 @@
 {
     "mcpServers": {
         "ssky": {
-            "command": "docker",
+            "command": "uvx",
             "args": [
-                "run",
-                "-i",
-                "--rm",
-                "-v",
-                "~/Pictures:/app/images",
-                "-e",
-                "SSKY_USER",
-                "ghcr.io/simpleskyclient/ssky-mcp:latest"
+                "--from",
+                "ssky[mcp]",
+                "ssky-mcp-server"
             ]
         }
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,10 @@ dependencies = [
     "beautifulsoup4 (>=4.12.3,<5.0.0)",
     "requests (>=2.32.3,<3.0.0)",
     "atproto (>=0.0.68,<0.0.69)",
-    "fastmcp (>=2.14.0,<3.0.0)",
 ]
+
+[project.optional-dependencies]
+mcp = ["fastmcp (>=2.14.0,<3.0.0)"]
 
 [project.urls]
 homepage = "https://github.com/simpleskyclient/ssky"

--- a/src/ssky_mcp/server.py
+++ b/src/ssky_mcp/server.py
@@ -8,10 +8,30 @@ import logging
 import subprocess
 import sys
 from importlib.metadata import version, PackageNotFoundError
-from fastmcp import FastMCP
 
 # Import ssky utilities (now we can import directly!)
 from ssky.util import create_success_response, create_error_response
+
+def require_fastmcp():
+    """Return the FastMCP class, or exit with an actionable message if the extra is missing.
+
+    fastmcp is an optional dependency: plain `pip install ssky` gives the CLI only.
+    Without this guard the entry point would fail with a bare ImportError traceback,
+    which does not tell the user what to do about it.
+    """
+    try:
+        from fastmcp import FastMCP
+    except ModuleNotFoundError as e:
+        if e.name != "fastmcp":
+            raise
+        sys.stderr.write(
+            "ssky-mcp-server requires the optional MCP dependencies, which are not installed.\n"
+            "Install them with:\n"
+            "\n"
+            "    pip install 'ssky[mcp]'\n"
+        )
+        raise SystemExit(1) from None
+    return FastMCP
 
 # Set logging level to WARNING and above for stderr output
 logging.basicConfig(level=logging.WARNING, stream=sys.stderr)
@@ -28,7 +48,7 @@ logging.getLogger("FastMCP.fastmcp.server.server").setLevel(logging.WARNING)
 logger = logging.getLogger("ssky_mcp_server")
 
 # Create FastMCP server
-mcp = FastMCP("ssky")
+mcp = require_fastmcp()("ssky")
 
 # Set the MCP server version (same as ssky package)
 def get_mcp_server_version():


### PR DESCRIPTION
Implements #75.

`fastmcp` is no longer a core dependency, and the documented MCP setup path leads with
the Python install instead of Docker.

## Packaging

```toml
[project.optional-dependencies]
mcp = ["fastmcp (>=2.14.0,<3.0.0)"]
```

Verified against the built wheel's metadata:

```
Provides-Extra: mcp
Requires-Dist: atproto (>=0.0.68,<0.0.69)
Requires-Dist: beautifulsoup4 (>=4.12.3,<5.0.0)
Requires-Dist: fastmcp (>=2.14.0,<3.0.0) ; extra == "mcp"
Requires-Dist: requests (>=2.32.3,<3.0.0)
```

`pip install ssky` now installs the CLI and nothing else; `pip install 'ssky[mcp]'` adds
the server.

## Actionable error instead of an ImportError

`server.py` imports fastmcp through `require_fastmcp()`, so a missing extra produces:

```
$ ssky-mcp-server
ssky-mcp-server requires the optional MCP dependencies, which are not installed.
Install them with:

    pip install 'ssky[mcp]'
```

exit code 1, no traceback. Verified by blocking the `fastmcp` import via a `sys.meta_path`
finder; also confirmed the CLI itself still runs with fastmcp unimportable.

## Docker demoted, not retired

- `mcp/mcp.sample.json` now uses `uvx --from 'ssky[mcp]' ssky-mcp-server`
- the previous Docker config moved to `mcp/mcp.docker.sample.json`
- README, `mcp/README.md`, and `SSKY_MCP_GUIDE.md` lead with the Python path and present
  Docker as the alternative for environments without Python
- the image, `build.sh`, and the ghcr publish step in `release.yml` are all untouched

The guide previously opened with "Docker is required to run the MCP server", which is no
longer true; that section is now split into a required Python part and an optional Docker
part. Section 2.1 (image directory) is marked Docker-only, since the container's inability
to see the host filesystem is what motivates the volume mount — the Python path takes
normal host paths.

**Whether to retire the Docker pipeline entirely is left open.** The RFC asks to check
ghcr pull counts first, and GitHub's package API exposes no download count for container
packages (`/users/simpleskyclient/packages/container/ssky-mcp` returns `version_count`
only), nor is one rendered on the package page. For scale: PyPI reports 74 downloads of
`ssky` in the last month, so the Docker MCP audience is necessarily a small fraction of
an already small number.

## Also

- `poetry install --extras mcp` in both Dockerfiles and the devcontainer `postCreateCommand`
  — extras are not installed by default, so these would otherwise build without fastmcp
- release notes template in `release.yml` documents the `ssky[mcp]` install path
- CLAUDE.md records the policy: **no new MCP tools; MCP capability follows the CLI**

## Testing

`SSKY_SKIP_REAL_API_TESTS=1 poetry run python -m pytest` — 152 passed, 1 skipped, 1 failed.

The failure, `test_login.py::test_05_login_profile_availability_check`, is **pre-existing
on `main`** and unrelated to this change: `login.py:32` does `raise ... from
SskySession.login_error` when `login_error` is not an exception, giving
`TypeError: exception causes must derive from BaseException`. Not fixed here.
