### PR TITLE
fix: correct the -S flag label in README and pin the flag-to-format mapping with tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ ssky get --thread --output ./threads
 ```
 
 **Thread Output Formatting:**
-- **Short/ID format** (`-S`, `-I`): Reply lines prefixed with `"| "`
+- **Short/ID format** (no flag, `-I`): Reply lines prefixed with `"| "`
 - **Long/Text format** (`-L`, `-T`): Posts within thread separated by `"|"`, independent threads by `"----------------"`
 - **JSON/simple-json**: Cannot be used with `--thread` (returns error)
 

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -29,8 +29,9 @@ parser, so every subcommand accepts the same set.
 | `-T` | `--text` | `text` | Text |
 | *(none)* | | `''` | Short |
 
-`-S` is **Simple JSON**. The README's thread-formatting section calls `-S` "Short", which
-is incorrect (#77).
+`-S` is **Simple JSON**; Short has no flag of its own and is what you get when no format
+flag is given. `tests/test_format_flags.py` pins this mapping so the documentation cannot
+drift away from the parser again (#77).
 
 Two more options affect output:
 

--- a/tests/test_format_flags.py
+++ b/tests/test_format_flags.py
@@ -1,0 +1,86 @@
+"""Pin the mapping from command-line format flags to internal format values.
+
+The README and CLAUDE.md have disagreed about what `-S` means (issue #77). These tests
+make the argument parser the arbiter, so the two documents cannot drift apart again
+without a test failing.
+
+`docs/OUTPUT_FORMATS.md` is the normative spec for what each format then emits.
+"""
+
+import pytest
+from unittest.mock import patch
+
+from ssky.main import parse
+
+
+def parse_argv(*argv):
+    """Run the real argument parser over argv and return (subcommand, args)."""
+    with patch('sys.argv', ['ssky', *argv]):
+        return parse()
+
+
+@pytest.mark.parametrize('flag,expected', [
+    ('-I', 'id'),
+    ('--id', 'id'),
+    ('-J', 'json'),
+    ('--json', 'json'),
+    ('-L', 'long'),
+    ('--long', 'long'),
+    ('-S', 'simple_json'),
+    ('--simple-json', 'simple_json'),
+    ('-T', 'text'),
+    ('--text', 'text'),
+])
+def test_format_flag_maps_to_expected_format(flag, expected):
+    _, args = parse_argv('get', flag)
+    assert args.format == expected
+
+
+def test_no_flag_means_short():
+    """Short is the unflagged default; it has no flag of its own."""
+    _, args = parse_argv('get')
+    assert args.format == ''
+
+
+def test_simple_json_is_not_short():
+    """Guards the specific error in the README: `-S` is Simple JSON, not Short."""
+    _, short = parse_argv('get')
+    _, simple_json = parse_argv('get', '-S')
+    assert simple_json.format == 'simple_json'
+    assert simple_json.format != short.format
+
+
+@pytest.mark.parametrize('subcommand,extra', [
+    ('get', []),
+    ('search', ['query']),
+    ('user', ['query']),
+    ('profile', ['someone.bsky.social']),
+    ('post', ['message']),
+    ('delete', ['at://did:plc:test/app.bsky.feed.post/abc']),
+    ('follow', ['someone.bsky.social']),
+    ('unfollow', ['someone.bsky.social']),
+    ('repost', ['at://did:plc:test/app.bsky.feed.post/abc']),
+    ('unrepost', ['at://did:plc:test/app.bsky.feed.post/abc']),
+    ('login', []),
+])
+def test_every_subcommand_accepts_the_same_format_flags(subcommand, extra):
+    """The format options are a shared parent parser, so the set must not vary."""
+    for flag, expected in [('-I', 'id'), ('-J', 'json'), ('-L', 'long'),
+                           ('-S', 'simple_json'), ('-T', 'text')]:
+        _, args = parse_argv(subcommand, *extra, flag)
+        assert args.format == expected, f'{subcommand} {flag}'
+
+
+def test_format_flags_are_mutually_exclusive():
+    with pytest.raises(SystemExit):
+        parse_argv('get', '-I', '-J')
+
+
+def test_delimiter_defaults_to_a_single_space():
+    _, args = parse_argv('get')
+    assert args.delimiter == ' '
+
+
+def test_output_defaults_to_none():
+    _, args = parse_argv('get')
+    assert args.output is None


### PR DESCRIPTION
Closes #77.

## The discrepancy

`CLAUDE.md` documented `-S` as `simple_json` with Short as the unflagged default. The
README's thread-formatting section labelled it `**Short/ID format** (`-S`, `-I`)`.

The parser settles it — `main.py` binds `-S`/`--simple-json` to `const='simple_json'`, and
the short format has no flag (`set_defaults(format='')`). **CLAUDE.md was right; the README
was wrong.**

Anyone who followed the README and reached for `-S` expecting the compact one-line form got
a JSON envelope instead.

## Fix

One line in the README: `(`-S`, `-I`)` → `(no flag, `-I`)`.

## Pin

`tests/test_format_flags.py` (26 cases) makes the parser the arbiter so the documents
cannot drift apart again:

- every flag and its long form maps to the expected internal value
- no flag means Short
- `-S` is explicitly asserted **not** to be Short — the specific error being fixed
- all eleven subcommands accept the same format flags, since they share one parent parser
- the flags are mutually exclusive
- `--delimiter` defaults to a single space and `--output` to `None`

The subcommand sweep is worth the repetition: the format options are shared via a parent
parser, so a future subcommand that builds its own parser would silently diverge, and this
catches that.

## Also

`docs/OUTPUT_FORMATS.md` §1 no longer describes the README as wrong, and points at the test
that now holds the mapping.

## Testing

`SSKY_SKIP_REAL_API_TESTS=1 poetry run python -m pytest` — 178 passed, 1 skipped, 1 failed.
The failure is the pre-existing one tracked in #92.
