### PR TITLE
fix: handle SIGPIPE without traceback

### DIFF
--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -63,8 +63,9 @@ command, not of the flags:
   today; defining one is #82.
 - Human-readable formats write errors to **stderr**. JSON formats write errors to
   **stdout** — see [Known divergences](#known-divergences) and #83.
-- A closed downstream pipe is caught (`BrokenPipeError` in `main.execute()`) and produces
-  no traceback, but the resulting exit code varies with payload size — see #84.
+- A closed downstream pipe (`ssky … | head`) restores default `SIGPIPE` handling and
+  exits with `128 + SIGPIPE` (typically `141`) without a traceback. `BrokenPipeError`
+  in the entry point is handled the same way as a fallback.
 
 ## 4. The matrix
 
@@ -333,7 +334,7 @@ deltas to work through.
 | --- | --- | --- | --- |
 | 1 | `--thread` refuses `-J`/`-S` | structured output for threads | #80, #81 |
 | 2 | Errors go to stdout under `-J`/`-S` | payload-only stdout, or an explicit documented exception | #83 |
-| 3 | SIGPIPE exit code varies with payload size (0 for small, 1 for large) | one documented code | #82, #84 |
+| 3 | SIGPIPE exit code varies with payload size (0 for small, 1 for large) | exit `128+SIGPIPE` (typically 141), no traceback | #84 |
 | 4 | A custom delimiter is not escaped in Short; `-D ,` on a display name containing `,` produces an unparseable line | specified escaping, or a NUL-delimited mode | #85 |
 | 5 | An absent `display_name` yields an empty field, so a space-delimited Short line silently loses a column | a placeholder, or a documented rule | #85 |
 | 6 | `PostDataList` envelope message reads `Posted N item(s)` even for `get` and `search` | wording that matches the operation | #93 |

--- a/docs/OUTPUT_FORMATS.md
+++ b/docs/OUTPUT_FORMATS.md
@@ -334,14 +334,13 @@ deltas to work through.
 | --- | --- | --- | --- |
 | 1 | `--thread` refuses `-J`/`-S` | structured output for threads | #80, #81 |
 | 2 | Errors go to stdout under `-J`/`-S` | payload-only stdout, or an explicit documented exception | #83 |
-| 3 | SIGPIPE exit code varies with payload size (0 for small, 1 for large) | exit `128+SIGPIPE` (typically 141), no traceback | #84 |
-| 4 | A custom delimiter is not escaped in Short; `-D ,` on a display name containing `,` produces an unparseable line | specified escaping, or a NUL-delimited mode | #85 |
-| 5 | An absent `display_name` yields an empty field, so a space-delimited Short line silently loses a column | a placeholder, or a documented rule | #85 |
-| 6 | `PostDataList` envelope message reads `Posted N item(s)` even for `get` and `search` | wording that matches the operation | #93 |
-| 7 | `DryRunResult` inverts the convention: `-S` bare and lossy, `-J` enveloped | `-S` enveloped like every other type | #94 |
-| 8 | `SuccessResult` ignores `-I`/`-T`/`-L`, so `ssky delete <uri> -I` prints prose instead of the URI | `-I` yields the affected identifier | #95 |
-| 9 | `-O` creates the directory for threads but not for posts or profiles | create it in all cases, or fail the same way in all cases | #96 |
-| 10 | Dead branch: `ThreadData._print_to_stdout` tests `format in ('long','text')` inside the branch that only runs for `''` and `'id'` | remove, or restore the intended separator | #96 |
+| 3 | A custom delimiter is not escaped in Short; `-D ,` on a display name containing `,` produces an unparseable line | specified escaping, or a NUL-delimited mode | #85 |
+| 4 | An absent `display_name` yields an empty field, so a space-delimited Short line silently loses a column | a placeholder, or a documented rule | #85 |
+| 5 | `PostDataList` envelope message reads `Posted N item(s)` even for `get` and `search` | wording that matches the operation | #93 |
+| 6 | `DryRunResult` inverts the convention: `-S` bare and lossy, `-J` enveloped | `-S` enveloped like every other type | #94 |
+| 7 | `SuccessResult` ignores `-I`/`-T`/`-L`, so `ssky delete <uri> -I` prints prose instead of the URI | `-I` yields the affected identifier | #95 |
+| 8 | `-O` creates the directory for threads but not for posts or profiles | create it in all cases, or fail the same way in all cases | #96 |
+| 9 | Dead branch: `ThreadData._print_to_stdout` tests `format in ('long','text')` inside the branch that only runs for `''` and `'id'` | remove, or restore the intended separator | #96 |
 
 Two further notes that are documentation rather than code:
 

--- a/src/ssky/main.py
+++ b/src/ssky/main.py
@@ -176,9 +176,17 @@ def main() -> int:
         status = execute(subcommand, args)
         return 0 if status is True else 1
     except BrokenPipeError:
+        # Quiet exit when BrokenPipeError surfaces from parse() (no execute
+        # dup2 yet) or after execute() re-raises. Narrow to OSError so we do
+        # not mask unrelated failures while still covering close failures.
+        try:
+            devnull = os.open(os.devnull, os.O_WRONLY)
+            os.dup2(devnull, sys.stdout.fileno())
+        except OSError:
+            pass
         try:
             sys.stdout.close()
-        except Exception:
+        except OSError:
             pass
         return 128 + int(getattr(signal, "SIGPIPE", 13))
 

--- a/src/ssky/main.py
+++ b/src/ssky/main.py
@@ -137,15 +137,27 @@ def execute(subcommand, args) -> bool:
         print(e, file=sys.stderr)
         return False
     except BrokenPipeError:
-        devnull = os.open(os.devnull, os.O_WRONLY)
-        os.dup2(devnull, sys.stdout.fileno())
-        return False
+        # Quiet exit for environments where SIGPIPE is not delivered as a
+        # signal (for example when stdout is a TextIOWrapper). Convention:
+        # 128 + SIGPIPE (typically 141).
+        try:
+            devnull = os.open(os.devnull, os.O_WRONLY)
+            os.dup2(devnull, sys.stdout.fileno())
+        except Exception:
+            pass
+        code = 128 + int(getattr(signal, "SIGPIPE", 13))
+        raise SystemExit(code)
     except Exception as e:
         print(str(e), file=sys.stderr)
         return False
 
 def setup():
     signal.signal(signal.SIGINT, lambda num, frame: sys.exit(1))
+    # Restore default SIGPIPE so a closed downstream pipe exits like other
+    # Unix CLIs (128 + SIGPIPE) instead of raising BrokenPipeError with a
+    # traceback at interpreter shutdown.
+    if hasattr(signal, "SIGPIPE"):
+        signal.signal(signal.SIGPIPE, signal.SIG_DFL)
     sys.stdin = io.TextIOWrapper(sys.stdin.buffer, encoding='utf-8')
     sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8', line_buffering=False)
     sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8', line_buffering=False)
@@ -159,9 +171,16 @@ def setup():
 
 def main() -> int:
     setup()
-    subcommand, args = parse()
-    status = execute(subcommand, args)
-    return 0 if status is True else 1
+    try:
+        subcommand, args = parse()
+        status = execute(subcommand, args)
+        return 0 if status is True else 1
+    except BrokenPipeError:
+        try:
+            sys.stdout.close()
+        except Exception:
+            pass
+        return 128 + int(getattr(signal, "SIGPIPE", 13))
 
 if __name__ == '__main__':
     sys.exit(main())

--- a/src/ssky/main.py
+++ b/src/ssky/main.py
@@ -138,15 +138,15 @@ def execute(subcommand, args) -> bool:
         return False
     except BrokenPipeError:
         # Quiet exit for environments where SIGPIPE is not delivered as a
-        # signal (for example when stdout is a TextIOWrapper). Convention:
-        # 128 + SIGPIPE (typically 141).
+        # signal (for example when stdout is a TextIOWrapper). Redirect
+        # stdout so interpreter shutdown flush cannot re-raise, then let
+        # main() turn the error into 128 + SIGPIPE (typically 141).
         try:
             devnull = os.open(os.devnull, os.O_WRONLY)
             os.dup2(devnull, sys.stdout.fileno())
-        except Exception:
+        except OSError:
             pass
-        code = 128 + int(getattr(signal, "SIGPIPE", 13))
-        raise SystemExit(code)
+        raise
     except Exception as e:
         print(str(e), file=sys.stderr)
         return False

--- a/tests/test_sigpipe.py
+++ b/tests/test_sigpipe.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import signal
 import subprocess
 import sys
@@ -34,6 +35,11 @@ def test_setup_restores_sigpipe_default():
 
 
 def test_execute_broken_pipe_reraise_after_dup2():
+    """execute() must re-raise BrokenPipeError after redirecting stdout.
+
+    Patch os.open/os.dup2 so the real pytest capture descriptors are not
+    replaced with /dev/null (that would break the rest of the suite).
+    """
     args = MagicMock()
     args.format = "id"
     args.output = None
@@ -42,44 +48,76 @@ def test_execute_broken_pipe_reraise_after_dup2():
     def _raise(**_kwargs):
         raise BrokenPipeError()
 
-    with patch("ssky.main.import_module") as imp:
+    with (
+        patch("ssky.main.import_module") as imp,
+        patch("ssky.main.os.open", return_value=99) as open_mock,
+        patch("ssky.main.os.dup2") as dup2_mock,
+    ):
         mod = MagicMock()
         mod.get = _raise
         imp.return_value = mod
         with pytest.raises(BrokenPipeError):
             main_mod.execute("get", args)
+        open_mock.assert_called_once_with(os.devnull, os.O_WRONLY)
+        dup2_mock.assert_called_once()
 
 
 def test_main_broken_pipe_returns_sigpipe_code():
+    """main() returns 128+SIGPIPE without closing pytest's captured stdout.
+
+    Patch dup2/open/close so teardown does not destroy capture FDs.
+    """
     expected = 128 + int(getattr(signal, "SIGPIPE", 13))
     with (
         patch("ssky.main.parse", return_value=("get", MagicMock())),
         patch("ssky.main.execute", side_effect=BrokenPipeError()),
         patch("ssky.main.setup"),
+        patch("ssky.main.os.open", return_value=99),
+        patch("ssky.main.os.dup2"),
+        patch.object(sys.stdout, "close"),
     ):
         assert main_mod.main() == expected
 
 
 def test_pipe_to_early_consumer_has_empty_stderr():
-    """Regression: early pipe close must not dump a traceback on stderr."""
+    """Regression: early pipe close through ssky setup must exit 141, no stderr."""
+    if not hasattr(signal, "SIGPIPE"):
+        pytest.skip("SIGPIPE not available on this platform")
+
+    # Drive real setup() (SIG_DFL + TextIOWrapper) and write past a typical
+    # pipe buffer so the writer hits the closed reader after head-style exit.
     code = (
-        "import signal, sys\n"
-        "if hasattr(signal, 'SIGPIPE'):\n"
-        "    signal.signal(signal.SIGPIPE, signal.SIG_DFL)\n"
-        "sys.stdout.write('line1\\n')\n"
-        "sys.stdout.flush()\n"
-        "sys.stdout.write('line2\\n')\n"
-        "sys.stdout.flush()\n"
+        "from ssky.main import setup\n"
+        "import sys\n"
+        "setup()\n"
+        "chunk = ('x' * 4096) + '\\n'\n"
+        "for _ in range(256):\n"
+        "    sys.stdout.write(chunk)\n"
+        "    sys.stdout.flush()\n"
     )
+    env = os.environ.copy()
+    # Ensure the subprocess can import the in-tree package the same way pytest does.
+    src = os.path.join(os.path.dirname(__file__), os.pardir, "src")
+    src = os.path.abspath(src)
+    env["PYTHONPATH"] = src + os.pathsep + env.get("PYTHONPATH", "")
+
     proc = subprocess.Popen(
         [sys.executable, "-c", code],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=env,
     )
     assert proc.stdout is not None and proc.stderr is not None
     _ = proc.stdout.readline()
     proc.stdout.close()
     stderr = proc.stderr.read()
-    proc.wait(timeout=5)
-    assert b"BrokenPipeError" not in stderr
-    assert b"Traceback" not in stderr
+    proc.wait(timeout=10)
+    # Popen reports -SIGPIPE when the child is killed by the signal; a shell
+    # would surface that as 128 + SIGPIPE (typically 141).
+    rc = proc.returncode
+    if rc is not None and rc < 0:
+        rc = 128 + (-rc)
+    assert rc == 128 + int(signal.SIGPIPE), (
+        f"expected 141, got {proc.returncode}; stderr={stderr!r}"
+    )
+    assert stderr == b"", f"stderr not empty: {stderr!r}"

--- a/tests/test_sigpipe.py
+++ b/tests/test_sigpipe.py
@@ -1,0 +1,63 @@
+"""SIGPIPE / BrokenPipeError handling (#84)."""
+
+from __future__ import annotations
+
+import signal
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ssky import main as main_mod
+
+
+def test_setup_restores_sigpipe_default():
+    if not hasattr(signal, "SIGPIPE"):
+        pytest.skip("SIGPIPE not available on this platform")
+    main_mod.setup()
+    assert signal.getsignal(signal.SIGPIPE) == signal.SIG_DFL
+
+
+def test_execute_broken_pipe_exits_with_sigpipe_code():
+    args = MagicMock()
+    args.format = "id"
+    args.output = None
+    args.delimiter = " "
+
+    def _raise(**_kwargs):
+        raise BrokenPipeError()
+
+    with patch("ssky.main.import_module") as imp:
+        mod = MagicMock()
+        mod.get = _raise
+        imp.return_value = mod
+        with pytest.raises(SystemExit) as ei:
+            main_mod.execute("get", args)
+    expected = 128 + int(getattr(signal, "SIGPIPE", 13))
+    assert ei.value.code == expected
+
+
+def test_pipe_to_early_consumer_has_empty_stderr():
+    """Regression: early pipe close must not dump a traceback on stderr."""
+    code = (
+        "import signal, sys\n"
+        "if hasattr(signal, 'SIGPIPE'):\n"
+        "    signal.signal(signal.SIGPIPE, signal.SIG_DFL)\n"
+        "sys.stdout.write('line1\\n')\n"
+        "sys.stdout.flush()\n"
+        "sys.stdout.write('line2\\n')\n"
+        "sys.stdout.flush()\n"
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", code],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert proc.stdout is not None and proc.stderr is not None
+    _ = proc.stdout.readline()
+    proc.stdout.close()
+    stderr = proc.stderr.read()
+    proc.wait(timeout=5)
+    assert b"BrokenPipeError" not in stderr
+    assert b"Traceback" not in stderr

--- a/tests/test_sigpipe.py
+++ b/tests/test_sigpipe.py
@@ -13,13 +13,27 @@ from ssky import main as main_mod
 
 
 def test_setup_restores_sigpipe_default():
+    """Run setup() in a subprocess so it cannot swap this process's stdio."""
     if not hasattr(signal, "SIGPIPE"):
         pytest.skip("SIGPIPE not available on this platform")
-    main_mod.setup()
-    assert signal.getsignal(signal.SIGPIPE) == signal.SIG_DFL
+
+    code = (
+        "import signal\n"
+        "from ssky.main import setup\n"
+        "signal.signal(signal.SIGPIPE, signal.SIG_IGN)\n"
+        "setup()\n"
+        "assert signal.getsignal(signal.SIGPIPE) == signal.SIG_DFL\n"
+    )
+    proc = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stderr
 
 
-def test_execute_broken_pipe_exits_with_sigpipe_code():
+def test_execute_broken_pipe_reraise_after_dup2():
     args = MagicMock()
     args.format = "id"
     args.output = None
@@ -32,10 +46,18 @@ def test_execute_broken_pipe_exits_with_sigpipe_code():
         mod = MagicMock()
         mod.get = _raise
         imp.return_value = mod
-        with pytest.raises(SystemExit) as ei:
+        with pytest.raises(BrokenPipeError):
             main_mod.execute("get", args)
+
+
+def test_main_broken_pipe_returns_sigpipe_code():
     expected = 128 + int(getattr(signal, "SIGPIPE", 13))
-    assert ei.value.code == expected
+    with (
+        patch("ssky.main.parse", return_value=("get", MagicMock())),
+        patch("ssky.main.execute", side_effect=BrokenPipeError()),
+        patch("ssky.main.setup"),
+    ):
+        assert main_mod.main() == expected
 
 
 def test_pipe_to_early_consumer_has_empty_stderr():


### PR DESCRIPTION
## Summary
Piping list output into an early-exiting consumer (for example `ssky get -I | head -1`) could surface a Python traceback on stderr.

- Restore default `SIGPIPE` handling at startup
- Exit with `128 + SIGPIPE` (typically 141) on `BrokenPipeError`
- Document the exit code in `docs/OUTPUT_FORMATS.md`
- Add regression tests for the signal default, exit code, and empty stderr on early pipe close

Fixes #84