### PR TITLE
docs: Add CONTRIBUTING.md and move the developer sections out of README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,13 @@ preserve it via `conftest.py`).
 - **Repository**: `simpleskyclient/ssky`, the `origin` remote — there is no fork. Push
   topic branches straight to it and open **issues** and **PRs** there. Confirm repo
   ownership before any GitHub operation.
+- **Check an issue is unclaimed before working it.** Look at both the issue comments and
+  open PRs referencing it (`gh pr list --search <issue>`) — an open PR is a claim even
+  with no comment. The `claimed` label flags taken issues, but the comments are the
+  record. **The assignee field proves nothing**: GitHub only allows assigning users with
+  repo access, so outside contributors are not assignable and a claimed issue still shows
+  no assignee. When someone volunteers, reply promptly to confirm and add `claimed`.
+  `CONTRIBUTING.md` states this contract for contributors.
 - **Releasing is automated, not manual.** Bump `version` in `pyproject.toml`, then push
   a `v*` tag to upstream — the `release.yml` GitHub Actions workflow handles PyPI publish,
   Docker image push to ghcr, and the GitHub Release. Don't run `poetry publish` by hand.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,114 @@
+# Contributing to ssky
+
+Thanks for your interest. Please read [Claiming an issue](#claiming-an-issue) before you
+write any code — it is the part that saves everyone wasted work.
+
+## Claiming an issue
+
+Two contributors recently built the same fix for the same issue in parallel, and one of
+them had to be turned away. That is our fault for not writing this down, so here it is.
+
+Before you start work:
+
+1. **Check the issue is open.** A closed issue is done; offering to take it means the fix
+   already shipped.
+2. **Check nobody is already on it.** A **`claimed`** label means someone has said they
+   are working on it. The label is a convenience, not the record, so also look at:
+   - the issue's comments, and
+   - **open pull requests that reference it** — the issue page lists linked PRs, or run
+     `gh pr list --repo simpleskyclient/ssky --search 84`.
+
+   An open PR is a claim even if nobody commented on the issue and the label is missing.
+3. **Comment on the issue** saying you'd like to take it. A maintainer will reply to
+   confirm, and that reply is the record that the issue is yours.
+
+You don't have to wait for the confirmation to start — but do comment *before* you start,
+so the next person can see the issue is taken. Opening a PR without commenting first is
+what caused the collision above.
+
+**Don't read anything into the assignee field.** GitHub only allows assigning people who
+already have access to the repository, so an issue claimed by an outside contributor will
+still show no assignee. An empty assignee field does not mean an issue is free — the
+comments are what count.
+
+If someone else has already claimed an issue, ask in the thread before starting parallel
+work.
+
+Maintainers: reply promptly when someone claims an issue, and add the `claimed` label so
+the state is visible from the issue list. Remove it if the claim is withdrawn or goes
+stale. A claim left without an answer is the state that causes duplicated work.
+
+## Development setup
+
+ssky requires Python 3.12 or later and uses [Poetry](https://python-poetry.org/).
+
+```bash
+poetry install --extras mcp    # dependencies, including the MCP server
+poetry install                 # CLI dependencies only, as end users get them
+```
+
+`fastmcp` is an optional extra (`ssky[mcp]`), not a core dependency — a plain
+`pip install ssky` must not pull it in.
+
+**Prefix Python and tool commands with `poetry run`** so they use the project virtualenv.
+
+### Dev Container
+
+For development using VS Code Dev Containers:
+
+1. Copy the environment configuration file and set your Bluesky credentials:
+   ```bash
+   cp .env.local.sample .env.local
+   ```
+   Edit `.env.local` and add your Bluesky handle and password:
+   ```bash
+   SSKY_USER=your-handle.bsky.social:your-password
+   SSKY_SKIP_REAL_API_TESTS=1
+   ```
+
+2. The dev container automatically:
+   - Loads environment variables from `.env.local`
+   - Installs Claude Code extension
+   - Sets up Python 3.14 environment with Docker support
+
+## Running the tests
+
+1. Copy the environment configuration file and set your Bluesky credentials:
+   ```bash
+   cp tests/_env tests/.env
+   ```
+   Edit `tests/.env` and add your Bluesky handle and password.
+
+2. Run the tests:
+   ```bash
+   poetry run pytest --tb=short             # the whole suite
+   poetry run pytest tests/test_login.py -v # a single file
+   ```
+
+Parts of the suite call the real Bluesky API. To skip those:
+
+```bash
+SSKY_SKIP_REAL_API_TESTS=1 poetry run pytest
+```
+
+Tests preserve your `~/.ssky` session file via `conftest.py`. Never delete it from
+production code.
+
+## Pull requests
+
+- Reference the issue in the PR body with `Fixes #<number>` so it closes on merge, and so
+  the issue page shows your PR to the next person checking whether it is taken.
+- **Commit messages are a single-line summary.** No body, no emoji, and no
+  `Generated with …` / `Co-Authored-By` footers.
+
+A few project rules worth knowing before you change behaviour:
+
+- **[`docs/OUTPUT_FORMATS.md`](docs/OUTPUT_FORMATS.md) is the normative spec** for CLI
+  output. If your change alters what a command prints, update the spec in the same PR —
+  including its "Known divergences" table, not just the prose.
+- **Facet positions are UTF-8 byte offsets, not character indices.** Multibyte text shifts
+  them, and facets must not overlap. See `src/ssky/post.py`.
+- **The MCP server shells out to the `ssky` CLI on purpose**, so CLI and MCP behaviour
+  cannot drift. Don't refactor it into library imports, and don't add MCP-only features —
+  capability follows the CLI.
+- Raise `SskyError` subclasses rather than generic exceptions.

--- a/README.md
+++ b/README.md
@@ -287,50 +287,13 @@ installing anything permanently — see `mcp/mcp.sample.json`.
 
 📖 **[Complete MCP Documentation](mcp/SSKY_MCP_GUIDE.md)**
 
-## 🧪 Development with Dev Container
+## 🤝 Contributing
 
-For development using VS Code Dev Containers:
+Contributions are welcome. **[CONTRIBUTING.md](CONTRIBUTING.md)** covers development
+setup, the Dev Container, running the tests, and how to open a pull request.
 
-1. Copy the environment configuration file and set your Bluesky credentials:
-   ```bash
-   cp .env.local.sample .env.local
-   ```
-   Edit `.env.local` and add your Bluesky handle and password:
-   ```bash
-   SSKY_USER=your-handle.bsky.social:your-password
-   SSKY_SKIP_REAL_API_TESTS=1
-   ```
-
-2. The dev container automatically:
-   - Loads environment variables from `.env.local`
-   - Installs Claude Code extension
-   - Sets up Python 3.14 environment with Docker support
-
-## 🧪 Testing
-
-To run the tests in the `tests/` directory:
-
-1. Copy the environment configuration file and set your Bluesky credentials:
-   ```bash
-   cp tests/_env tests/.env
-   ```
-   Edit `tests/.env` and add your Bluesky handle and password.
-
-2. Run tests using pytest:
-   ```bash
-   # Run all tests
-   pytest tests/ -v
-
-   # Run individual feature tests
-   pytest tests/test_login.py -v              # Login functionality
-   pytest tests/test_post_and_delete.py -v    # Post and delete operations
-   pytest tests/test_search.py -v             # Search functionality
-   pytest tests/test_follow_unfollow.py -v    # Follow/unfollow operations
-   pytest tests/test_get.py -v                # Timeline retrieval
-   pytest tests/test_profile.py -v            # Profile display
-   pytest tests/test_repost_unrepost.py -v    # Repost/unrepost operations
-   pytest tests/test_user.py -v               # User functionality
-   ```
+Please read the claiming convention there before you start work: comment on an issue to
+claim it, and check whether an open pull request already references it.
 
 ## 📝 Requirements
 


### PR DESCRIPTION
Fixes #101

Adds `CONTRIBUTING.md`: the claiming convention, development setup, the Dev Container,
running the tests, and the PR rules.

The Dev Container and Testing sections move out of `README.md`, which keeps a Contributing
section linking across. Two corrections made while moving: test commands now carry the
`poetry run` prefix, and `SSKY_SKIP_REAL_API_TESTS` is documented — both per `CLAUDE.md`.
The per-file list of eight test invocations is replaced by two examples; it was missing
six of the fourteen files in `tests/` and would keep drifting. The `tests/_env` →
`tests/.env` instructions move verbatim, since #35 covers deprecating them.

`CLAUDE.md` gains the same claiming check, so agent sessions verify an issue is unclaimed
before working it.

On claiming: GitHub only allows assigning users who already have repo access, so an
outside contributor's claim can never appear in the assignee field. Claims are recorded by
a maintainer's confirming comment, with the new `claimed` label for visibility in the
issue list.
